### PR TITLE
56 bug verzögerung bei bedienung der wallbox via integration

### DIFF
--- a/custom_components/enpal_webparser/button.py
+++ b/custom_components/enpal_webparser/button.py
@@ -17,6 +17,7 @@
 # See README.md for setup and usage instructions.
 #
 
+import asyncio
 from functools import cached_property
 import logging
 
@@ -90,6 +91,9 @@ class EnpalWallboxButton(ButtonEntity):
                     _LOGGER.info("[Enpal] Wallbox command successful: %s", self._url)
         except Exception as e:
             _LOGGER.exception("[Enpal] Wallbox request failed: %s", e)
+
+        # Wait a moment to allow the wallbox to process the change
+        await asyncio.sleep(2)
 
         await self._hass.services.async_call(
             "homeassistant",

--- a/custom_components/enpal_webparser/const.py
+++ b/custom_components/enpal_webparser/const.py
@@ -22,6 +22,7 @@ DOMAIN = "enpal_webparser"
 # --- Default Connection Settings ---
 DEFAULT_URL = "http://192.168.178.178/deviceMessages"
 DEFAULT_INTERVAL = 60
+
 DEFAULT_GROUPS = [
     "Wallbox",
     "Battery",
@@ -30,6 +31,7 @@ DEFAULT_GROUPS = [
     "IoTEdgeDevice",
     "PowerSensor",
 ]
+
 DEFAULT_USE_WALLBOX_ADDON = False
 DEFAULT_WALLBOX_API_ENDPOINT = "http://localhost:36725/wallbox"
 
@@ -62,6 +64,13 @@ DEVICE_CLASS_OVERRIDES = {
     "energy_battery_charge_level_absolute": "battery",
 }
 
+STATE_CLASS_OVERRIDES = {
+    "energy_battery_charge_level": "measurement",
+    "energy_battery_charge_level_unit_1": "measurement",
+    "energy_battery_charge_level_unit_2": "measurement",
+    "energy_battery_charge_level_absolute": "measurement",
+}
+
 # --- Wallbox Mode Mapping ---
 WALLBOX_MODE_MAP = {
     "eco": "Eco",
@@ -71,7 +80,6 @@ WALLBOX_MODE_MAP = {
 
 # --- Date/Time Formats ---
 ENPAL_TIMESTAMP_FORMAT = "%m/%d/%Y %H:%M:%S"
-
 
 ICON_MAP = {
     # IoT Edge Device
@@ -216,9 +224,3 @@ ICON_MAP = {
     "voltage_wallbox_connector_1_phase_c": "mdi:transmission-tower",
 }
 
-STATE_CLASS_OVERRIDES = {
-    "energy_battery_charge_level": "measurement",
-    "energy_battery_charge_level_unit_1": "measurement",
-    "energy_battery_charge_level_unit_2": "measurement",
-    "energy_battery_charge_level_absolute": "measurement",
-}

--- a/custom_components/enpal_webparser/select.py
+++ b/custom_components/enpal_webparser/select.py
@@ -17,6 +17,7 @@
 # See README.md for setup and usage instructions.
 #
 
+import asyncio
 import logging
 from functools import cached_property
 
@@ -98,6 +99,9 @@ class EnpalWallboxModeSelect(SelectEntity):
             self.async_write_ha_state()
 
             await self._call_wallbox_api(f"/set_{key}")
+
+            # Wait a moment to allow the wallbox to process the change
+            await asyncio.sleep(2)
 
             await self._hass.services.async_call(
                 "homeassistant",

--- a/custom_components/enpal_webparser/switch.py
+++ b/custom_components/enpal_webparser/switch.py
@@ -118,10 +118,10 @@ class EnpalWallboxSwitch(SwitchEntity):
                 else:
                     _LOGGER.debug("Wallbox API call success: %s", url)
 
-                    # Kurze Verzögerung für Übernahme des Status
+                    # Short wait to allow wallbox to process the change
                     await asyncio.sleep(2)
 
-                    # Sensoren aktiv aktualisieren
+                    # Get new status after command
                     await self._hass.services.async_call(
                         "homeassistant", "update_entity",
                         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add short delay before updating Wallbox sensors after API calls

## Description
Added an `asyncio.sleep()` delay before triggering a `homeassistant.update_entity` call to ensure that the Wallbox has enough time to apply the new state before Home Assistant refreshes the sensor values.

The delay was introduced in:
- `button.py`
- `select.py`

A similar delay was already present in `switch.py`.

## Motivation and Context
Without a short delay, Home Assistant sometimes refreshed the Wallbox sensor state too early, leading to inconsistent or outdated values in the UI.  
This change ensures more reliable and consistent state updates after Wallbox API calls.

## How Has This Been Tested?
- Tested locally with an Enpal Wallbox setup.  
- Triggered changes via button, select, and switch entities.  
- Verified that the sensor values update correctly after the delay and reflect the actual Wallbox state.  
- No regressions observed in normal operation.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
