### PR TITLE
62 bug config entry explicitly is deprecated in 202512

### DIFF
--- a/custom_components/enpal_webparser/config_flow.py
+++ b/custom_components/enpal_webparser/config_flow.py
@@ -68,6 +68,7 @@ async def validate_enpal_url(hass, url: str) -> bool:
         _LOGGER.warning("[Enpal] URL not reachable: %s", e)
         return False
 
+
 async def validate_wallbox_api(hass) -> bool:
     url = f"{DEFAULT_WALLBOX_API_ENDPOINT}/status"
     try:
@@ -94,16 +95,20 @@ def get_default_config(options: dict[str, Any] | None = None) -> dict[str, Any]:
         "use_wallbox_addon": src.get("use_wallbox_addon", DEFAULT_USE_WALLBOX_ADDON),
     }
 
+
 def get_form_schema(config: dict[str, Any]) -> vol.Schema:
-    return vol.Schema({
-        vol.Required("url", default=cast(Any, config["url"])): str,
-        vol.Required("interval", default=cast(Any, config["interval"])): int,
-        vol.Optional("groups", default=cast(Any, config["groups"])): cv.multi_select(DEFAULT_GROUPS),
-        vol.Optional("use_wallbox_addon", default=cast(Any, config["use_wallbox_addon"])): bool,
-    })
+    return vol.Schema(
+        {
+            vol.Required("url", default=cast(Any, config["url"])): str,
+            vol.Required("interval", default=cast(Any, config["interval"])): int,
+            vol.Optional("groups", default=cast(Any, config["groups"])): cv.multi_select(DEFAULT_GROUPS),
+            vol.Optional("use_wallbox_addon", default=cast(Any, config["use_wallbox_addon"])): bool,
+        }
+    )
+
 
 async def process_user_input(hass, user_input: dict[str, Any]) -> tuple[dict[str, Any] | None, dict[str, str]]:
-    errors = {}
+    errors: dict[str, str] = {}
     url_input = user_input["url"]
     url_checked, error = sanitize_url(url_input)
 
@@ -132,7 +137,7 @@ class EnpalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         _LOGGER.info("[Enpal] Config flow started")
         config = get_default_config()
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
             _LOGGER.debug("[Enpal] User input: %s", user_input)
@@ -154,17 +159,17 @@ class EnpalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        return EnpalOptionsFlowHandler()
+        return EnpalOptionsFlowHandler(config_entry)
 
 
 class EnpalOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry):
-        pass
+        self._config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         _LOGGER.info("[Enpal] OptionsFlow started")
-        config = get_default_config(dict(self.config_entry.options))
-        errors = {}
+        config = get_default_config(dict(self._config_entry.options))
+        errors: dict[str, str] = {}
 
         if user_input:
             _LOGGER.debug("[Enpal] OptionsFlow input: %s", user_input)


### PR DESCRIPTION
Solves an error message in homeassistant.log

## Description
Changes the way "config_entry" is handled in config_flow.py

## Motivation and Context
https://developers.home-assistant.io/blog/2024/11/12/options-flow/

## How Has This Been Tested?
Changes made, new configuration and reconfiguration (config flow and options flow) tested manually

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
