### PR TITLE
Added default "measurement" state_class

### DIFF
--- a/custom_components/enpal_webparser/entity_factory.py
+++ b/custom_components/enpal_webparser/entity_factory.py
@@ -49,7 +49,19 @@ class EnpalBaseSensor(CoordinatorEntity, SensorEntity):
         else:
             self._attr_device_class = device_class
         
-        # Overrides for state class if specified
+        # allow explicit state_class from sensor dict
+        self._attr_state_class = self._sensor.get("state_class")
+
+        # measurement state class for numeric sensors if not explicitly set
+        numeric_device_classes = {
+            "power", "voltage", "current", "temperature", "frequency",
+            "battery", "humidity", "pressure"
+        }
+        if self._attr_state_class is None:
+            if device_class in numeric_device_classes or self._attr_native_unit_of_measurement in {"W","kW","V","A","Hz","°C","%"}:
+                self._attr_state_class = "measurement"
+
+        # custom overrides for state class if specified
         sensor_id = self._attr_unique_id
         if sensor_id in STATE_CLASS_OVERRIDES:
             self._attr_state_class = STATE_CLASS_OVERRIDES[sensor_id]


### PR DESCRIPTION
Allow long term statistics.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added default "measurement" state_class to all numeric sensors.

## Motivation and Context
Sensors missing "measurement" state_class do not show up in HA long term statistics


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
