### PR TITLE
Fix #127: Wallbox-Status-Erkennung für Firmware-Namensvarianten + Reparatur-Flow (2.9.9b4)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,6 +26,7 @@ This is a Home Assistant custom integration that reads data from local Enpal sol
 - **`sensor.py`**: Platform setup with DataUpdateCoordinator, fallback to last known data on errors, cumulative energy sensors
 - **`config_flow.py`**: Multi-step UI configuration with auto-discovery and manual setup options, URL validation, group selection, wallbox toggle
 - **`discovery.py`**: Network scanning utilities for auto-discovering Enpal boxes on local subnets
+- **`repairs.py`**: HA repair flow. Surfaces a fixable issue when wallbox control is enabled but no wallbox status source could be auto-detected; the flow lets the user pick the raw sensor and writes it to the `wallbox_status_source` option (see below)
 - **`wallbox_api.py`**: Centralized API client for all wallbox communication. Blazor-first (`_control`) with add-on (port 36725) fallback; not coupled to `use_native`
 - **`api/websocket_client.py`**: Blazor SignalR client. Connect/handshake, ping loop, message read loop. Handles `JS.RenderBatch` pushes incrementally (see below) and exposes `_scrape_and_parse()` as the full-scrape baseline source
 - **`api/render_batch.py`**: Decodes the Blazor RenderBatch binary payload (`parse_render_batch_strings`, `extract_changed_rows`, `is_patchable_value`). Pure functions, defensive: returns `[]` on malformed/empty frames
@@ -147,11 +148,12 @@ _LOGGER.info("[Enpal] Your message: %s", variable)  # Always prefix with [Enpal]
 2. **Timestamp Parsing**: Use `ENPAL_TIMESTAMP_FORMAT = "%m/%d/%Y %H:%M:%S"` - Enpal uses MM/DD/YYYY format
 3. **Unit Conversion**: Wh → kWh conversion happens in `normalize_value_and_unit()` to match HA energy dashboard expectations
 4. **Wallbox Status Dependency**: Switch/select entities listen to `sensor.wallbox_status` state changes - ensure sensor exists before enabling controls
-5. **Test Isolation**: Tests don't use pytest parametrize - each test explicitly constructs scenarios for clarity
+5. **Wallbox status source naming varies by firmware**: The raw status sensor can be `Status.Wallbox.Connector.1` (→ `status_wallbox_connector_1`) or `Status.Connector.1` (→ `wallbox_status_connector_1`, e.g. Enpal ArC GEN2). Both are in `WALLBOX_STATUS_SOURCE_CANDIDATES` (`const.py`). `Status.Wallbox.Connected` (1/0 attach flag) is intentionally NOT a candidate. If auto-detect fails, `sensor.py` `_manage_wallbox_status_issue()` raises a repair issue and `repairs.py` lets the user pick the source.
+6. **Test Isolation**: Tests don't use pytest parametrize - each test explicitly constructs scenarios for clarity
 
 ## Branch Context
-Current branch: `dev` (manifest version `2.9.9b3`).
-Recent work: Firmware-8.50 adaptation. WebSocket/native wallbox mode, dynamic runtime sensor creation with `RestoreEntity`, and Phase 4 = incremental RenderBatch parsing to reduce the Enpal box CPU load (fast-path diff + 60 s full-scrape safety net).
+Current branch: issue-127 fix branch (manifest version `2.9.9b4`).
+Recent work: Firmware-8.50 adaptation (WebSocket/native wallbox mode, dynamic runtime sensor creation with `RestoreEntity`, incremental RenderBatch parsing). 2.9.9b4 adds the second wallbox status candidate (`wallbox_status_connector_1`) and an HA repair issue + fix flow (`repairs.py`) for unresolved wallbox status sources.
 
 ## Documentation Writing Style (README, Release Notes, German user-facing docs)
 User-facing docs are written in German. Avoid AI-typical phrasing and "AI slop". Target style: short, concrete declarative sentences.

--- a/README.md
+++ b/README.md
@@ -20,16 +20,17 @@ Eine Home Assistant Custom Integration zur lokalen Überwachung von Enpal Solara
 
 ---
 
-> ## ⚠️ Beta 2.9.9b3 — Firmware 8.50 erforderlich
+> ## ⚠️ Beta 2.9.9b4 — Firmware 8.50 erforderlich
 >
 > Diese Beta-Version ist auf die Enpal-Firmware **Solar Rel. 8.50.1-773465 (27.05.2026)** ausgerichtet und damit getestet.
 >
 > - Der **WebSocket-Modus** (Echtzeit-Daten) und die **native Wallbox-Steuerung ohne Add-on** setzen Firmware **8.50** voraus.
 > - Das **inkrementelle RenderBatch-Parsing** (neu in 2.9.9b3) senkt die CPU-Last der Enpal Box. Es basiert auf dem Datenformat von Firmware **8.50**.
+> - **Wallbox-Status-Erkennung verbessert (neu in 2.9.9b4):** Findet die Integration bei aktiver Wallbox-Steuerung keinen passenden Status-Sensor, erscheint eine Reparatur-Meldung in Home Assistant. Darüber wählst du den richtigen Sensor direkt aus.
 > - Auf älteren Firmware-Ständen läuft weiterhin der **HTML-Polling-Modus (Legacy)**, ohne die neuen Echtzeit- und Wallbox-Funktionen.
 > - **Wallbox im WebSocket-Modus:** Das Wallbox Add-on bzw. die Wallbox App wird nicht mehr benötigt. Die Integration steuert die Wallbox direkt. Stoppe das alte Add-on bzw. die App in diesem Fall, sonst kommt es zu doppelten Steuerbefehlen.
 > - **Fehlende Sensoren:** Seit Firmware **8.50** stellt Enpal einige Sensoren nicht mehr bereit. Die Integration kann das nicht ändern. Betroffene Entitäten kannst du in Home Assistant gefahrlos löschen.
-> - Lege vor der Installation ein **Home Assistant-Backup** an. Details in den [Release Notes 2.9.9b3](docs/RELEASE_NOTES_2.9.9b3.md).
+> - Lege vor der Installation ein **Home Assistant-Backup** an. Details in den [Release Notes 2.9.9b4](docs/RELEASE_NOTES_2.9.9b4.md).
 
 ---
 
@@ -283,6 +284,9 @@ Enpal aktualisiert gelegentlich die Firmware, was zu temporär fehlenden Sensore
 2. Wallbox Add-on / App in Integration aktiviert?
 3. Add-on / App Logs prüfen: **Einstellungen** → **Add-ons** / **Apps** → **Enpal Wallbox Control** → **Protokoll**
 4. Sensor `sensor.wallbox_status` vorhanden und aktualisiert?
+
+> ℹ️ **Wallbox-Status bleibt `unknown` (seit 2.9.9b4):**
+> Je nach Firmware liefert die Enpal Box den Status-Sensor unter verschiedenen Namen. Findet die Integration bei aktiver Wallbox-Steuerung keinen passenden Status-Sensor, legt sie eine Reparatur-Meldung an (**Einstellungen → System → Reparaturen**). Über **Beheben** wählst du den richtigen Sensor aus. Danach lädt die Integration neu und der Status wird angezeigt.
 
 </details>
 

--- a/custom_components/enpal_webparser/const.py
+++ b/custom_components/enpal_webparser/const.py
@@ -103,6 +103,9 @@ WALLBOX_STATUS_SOURCE_CANDIDATES = [
     # at all (1/0), NOT the vehicle connection/charge state, so it is intentionally
     # NOT used here.
     "status_wallbox_connector_1",
+    # Some firmware variants (e.g. Enpal ArC GEN2 SW 2.3.1) expose the same value
+    # as Status.Connector.1 -> "Wallbox: Status Connector 1" -> this key instead.
+    "wallbox_status_connector_1",
 ]
 
 # --- Date/Time Formats ---

--- a/custom_components/enpal_webparser/manifest.json
+++ b/custom_components/enpal_webparser/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/derolli1976/enpal/issues",
   "requirements": ["beautifulsoup4", "psutil"],
-  "version": "2.9.9b3"
+  "version": "2.9.9b4"
 }

--- a/custom_components/enpal_webparser/repairs.py
+++ b/custom_components/enpal_webparser/repairs.py
@@ -1,0 +1,85 @@
+# pyright: reportIncompatibleVariableOverride=false
+#
+# Home Assistant Custom Component: Enpal Webparser
+#
+# File: repairs.py
+#
+# Description:
+#   Repair flows for the Enpal Webparser integration. Currently handles the
+#   case where wallbox control is enabled but no matching "Wallbox Status"
+#   source sensor could be auto-detected (e.g. firmware naming variants). The
+#   flow lets the user pick the correct raw Wallbox sensor and stores it in the
+#   ``wallbox_status_source`` option.
+#
+# Author:       Oliver Stock (github.com/derolli1976)
+# License:      MIT
+# Repository:   https://github.com/derolli1976/enpal
+#
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+
+from .config_flow import get_wallbox_source_options
+from .const import DEFAULT_URL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WallboxStatusSourceRepairFlow(RepairsFlow):
+    """Let the user select the raw Wallbox status sensor."""
+
+    def __init__(self, entry_id: str) -> None:
+        self._entry_id = entry_id
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> data_entry_flow.FlowResult:
+        return await self.async_step_select()
+
+    async def async_step_select(
+        self, user_input: dict[str, Any] | None = None
+    ) -> data_entry_flow.FlowResult:
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None:
+            return self.async_abort(reason="entry_not_found")
+
+        if user_input is not None:
+            options = dict(entry.options)
+            options["wallbox_status_source"] = user_input["wallbox_status_source"]
+            self.hass.config_entries.async_update_entry(entry, options=options)
+            _LOGGER.info(
+                "[Enpal] Wallbox status source set to %s via repair flow",
+                user_input["wallbox_status_source"],
+            )
+            # The update listener reloads the entry; sensor.py then re-evaluates
+            # the source and deletes the issue if it now resolves.
+            return self.async_create_entry(title="", data={})
+
+        url = entry.options.get("url", DEFAULT_URL)
+        sources = await get_wallbox_source_options(self.hass, url)
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    "wallbox_status_source",
+                    default=entry.options.get("wallbox_status_source", "auto"),
+                ): vol.In(sources)
+            }
+        )
+        return self.async_show_form(step_id="select", data_schema=schema)
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, Any] | None,
+) -> RepairsFlow:
+    """Create the repair flow for an Enpal issue."""
+    entry_id = (data or {}).get("entry_id", "")
+    return WallboxStatusSourceRepairFlow(entry_id)

--- a/custom_components/enpal_webparser/sensor.py
+++ b/custom_components/enpal_webparser/sensor.py
@@ -28,6 +28,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
@@ -74,6 +75,39 @@ def _find_wallbox_source(data, configured, candidates):
         if candidate in available:
             return candidate
     return None
+
+
+def _wallbox_status_issue_id(entry: ConfigEntry) -> str:
+    return f"wallbox_status_source_missing_{entry.entry_id}"
+
+
+def _manage_wallbox_status_issue(hass, entry, data, status_source) -> None:
+    """Surface a repairs issue when the wallbox status source can't be resolved.
+
+    Only raised when the box actually exposes Wallbox-group sensors (so the data
+    is there but the name did not match any auto-detect candidate). In that case
+    the user can pick the correct sensor via the repair flow, which writes it to
+    the ``wallbox_status_source`` option.
+    """
+    issue_id = _wallbox_status_issue_id(entry)
+    has_wallbox_sensors = any(
+        "wallbox" in make_id(s.get("name", "")) for s in (data or [])
+    )
+    if status_source is None and has_wallbox_sensors:
+        _LOGGER.warning(
+            "[Enpal] Wallbox enabled but no status source matched; raising repair issue"
+        )
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="wallbox_status_source_missing",
+            data={"entry_id": entry.entry_id},
+        )
+    else:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
@@ -247,6 +281,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             entry.options.get("wallbox_status_source"),
             WALLBOX_STATUS_SOURCE_CANDIDATES,
         )
+
+        _manage_wallbox_status_issue(hass, entry, coordinator.data, status_source)
 
         if mode_source or status_source:
             _LOGGER.info(

--- a/custom_components/enpal_webparser/translations/de.json
+++ b/custom_components/enpal_webparser/translations/de.json
@@ -64,5 +64,24 @@
       "unreachable": "Die URL konnte nicht erreicht werden - bitte Verbindung und Adresse prüfen.",
       "wallbox_unreachable": "Die Wallbox-API ist nicht erreichbar. Stelle sicher, dass das Add-on läuft und erreichbar ist! Test: http://Homeassistant-IP-ADRESSE:36725/wallbox/status"
     }
+  },
+  "issues": {
+    "wallbox_status_source_missing": {
+      "title": "Wallbox-Status-Sensor konnte nicht erkannt werden",
+      "fix_flow": {
+        "step": {
+          "select": {
+            "title": "Wallbox-Status-Sensor auswählen",
+            "description": "Die Wallbox-Steuerung ist aktiv, aber es wurde automatisch kein passender Status-Sensor gefunden. Das kommt bei manchen Firmware-Versionen vor, die einen anderen Sensornamen verwenden. Wähle den Sensor aus, der den Wallbox-Status zeigt (z. B. Available/Charging).",
+            "data": {
+              "wallbox_status_source": "Wallbox-Status-Sensor"
+            }
+          }
+        },
+        "abort": {
+          "entry_not_found": "Der Integrations-Eintrag wurde nicht mehr gefunden."
+        }
+      }
+    }
   }
 }

--- a/custom_components/enpal_webparser/translations/en.json
+++ b/custom_components/enpal_webparser/translations/en.json
@@ -64,5 +64,24 @@
       "unreachable": "The URL could not be reached - please check the connection and address.",
       "wallbox_unreachable": "The Wallbox API is not reachable. Make sure the add-on is running and accessible! Test: http://Home-Assistant-IP-ADDRESS:36725/wallbox/status"
     }
+  },
+  "issues": {
+    "wallbox_status_source_missing": {
+      "title": "Wallbox status sensor could not be detected",
+      "fix_flow": {
+        "step": {
+          "select": {
+            "title": "Select Wallbox status sensor",
+            "description": "Wallbox control is enabled, but no matching status sensor was detected automatically. This can happen with some firmware versions that use a different sensor name. Pick the sensor that shows the Wallbox status (e.g. Available/Charging).",
+            "data": {
+              "wallbox_status_source": "Wallbox status sensor"
+            }
+          }
+        },
+        "abort": {
+          "entry_not_found": "The integration entry could no longer be found."
+        }
+      }
+    }
   }
 }

--- a/docs/RELEASE_NOTES_2.9.9b4.md
+++ b/docs/RELEASE_NOTES_2.9.9b4.md
@@ -1,0 +1,111 @@
+# 2.9.9b4 - Bessere Wallbox-Status-Erkennung & Reparatur-Meldung (Beta)
+
+---
+
+## ⚠️ BETA-VERSION — WICHTIGE HINWEISE
+
+> **Dies ist eine Beta-Version und nicht für den produktiven Einsatz gedacht.**
+>
+> - 🧪 **Nur zum Testen.** Diese Version kann noch Fehler enthalten.
+> - 💾 **Backup erstellen.** Lege vor der Installation ein Home Assistant-Backup an.
+> - 🔄 **Downgrade möglich.** Bei Problemen kannst du über HACS jederzeit auf die stabile Version 2.3.0 zurückwechseln (drei Punkte → Version auswählen).
+> - 🐛 **Fehler melden.** Bitte melde Fehler und Auffälligkeiten auf [GitHub Issues](https://github.com/derolli1976/enpal/issues).
+
+---
+
+## 🔌 Wichtig: Enpal-Firmware 8.50 erforderlich
+
+> **Die Echtzeit- und Wallbox-Funktionen setzen die Enpal-Firmware
+> `Solar Rel. 8.50.1-773465 (27.05.2026)` voraus.**
+>
+> - Der **WebSocket-Modus** (Echtzeit-Daten) und die **native Wallbox-Steuerung ohne Add-on** funktionieren nur mit Firmware **8.50**.
+> - Das **inkrementelle RenderBatch-Parsing** basiert auf dem Datenformat von Firmware **8.50**.
+> - Auf älteren Firmware-Ständen bleibt der **HTML-Polling-Modus (Legacy)** nutzbar, ohne die neuen Echtzeit- und Wallbox-Funktionen.
+> - Enpal verteilt die Firmware automatisch. Eine manuelle Auswahl ist nicht möglich.
+
+---
+
+## 🎉 Was ist neu in 2.9.9b4?
+
+### Wallbox-Status wird zuverlässiger erkannt
+
+**Das Problem:** Je nach Firmware liefert die Enpal Box den Wallbox-Status-Sensor unter
+unterschiedlichen Namen. Auf manchen Boxen (z.B. Enpal ArC GEN2) heißt der Rohsensor
+`Status.Connector.1` statt `Status.Wallbox.Connector.1`. Die automatische Erkennung hat diesen
+Namen bisher nicht berücksichtigt, dadurch blieb `sensor.wallbox_status` dauerhaft `unknown`.
+
+**Die Lösung:** Die automatische Erkennung berücksichtigt jetzt beide Namensvarianten. Auf den
+betroffenen Boxen wird der Wallbox-Status ohne weitere Einstellungen korrekt angezeigt.
+
+### Reparatur-Meldung bei fehlendem Status-Sensor
+
+Falls die Box den Status-Sensor unter einem noch unbekannten Namen liefert, bleibt das Problem
+nicht länger im Verborgenen:
+
+- Ist die **Wallbox-Steuerung aktiv**, findet die Integration aber keinen passenden Status-Sensor,
+  legt sie eine **Reparatur-Meldung** in Home Assistant an (**Einstellungen → System →
+  Reparaturen**).
+- Über **Beheben** öffnet sich ein Dialog, in dem du den richtigen Wallbox-Sensor direkt auswählst.
+- Nach der Auswahl lädt die Integration neu und zeigt den Status an. Die Meldung verschwindet
+  automatisch, sobald der Status-Sensor gefunden wird.
+
+Die Meldung erscheint nur, wenn die Box tatsächlich Wallbox-Sensoren liefert, der Name aber nicht
+zur automatischen Erkennung passt. Auf älteren Boxen ohne native Wallbox-Sensoren wird keine
+Meldung angelegt.
+
+---
+
+## 🔧 Installation der Beta
+
+### Über HACS:
+1. In HACS → **Enpal Solar** öffnen
+2. Auf die **drei Punkte** (⋮) klicken → **Version auswählen**
+3. Version **2.9.9b4** auswählen und installieren
+4. Home Assistant **neu starten**
+
+### Bestehende Beta-Installation upgraden:
+1. Version **2.9.9b4** über HACS installieren (siehe oben)
+2. Home Assistant **neu starten**
+3. Es sind keine Konfigurationsänderungen nötig. Bestehende Einstellungen bleiben erhalten.
+
+---
+
+## ⚠️ Bekannte Einschränkungen (Beta)
+
+- **Firmware 8.50 nötig** für WebSocket-, Wallbox- und RenderBatch-Funktionen (siehe oben).
+- **Wallbox App / Add-on im WebSocket-Modus deaktivieren.** Es wird nicht mehr gebraucht und kann sonst mit der direkten Steuerung kollidieren.
+- **Mehrdeutige Sensoren** (gleicher Name in mehreren Gruppen) aktualisieren erst im Vollabgleich-Intervall statt in Echtzeit.
+- **WebSocket-Verfügbarkeit:** Nicht alle Enpal-Boxen unterstützen WebSocket. Die Integration erkennt das automatisch und fällt im Zweifel auf HTML-Polling zurück.
+
+---
+
+## 📋 Zurück zur stabilen Version
+
+Falls Probleme auftreten:
+
+1. In HACS → **Enpal Solar** öffnen
+2. Auf die **drei Punkte** (⋮) klicken → **Version auswählen**
+3. Version **2.3.0** (stabile Version) auswählen und installieren
+4. Home Assistant **neu starten**
+
+Alle bisherigen Sensoren und Einstellungen bleiben erhalten.
+
+---
+
+## ℹ️ Kompatibilität
+
+- **Rückwärtskompatibel**: Bestehende Installationen werden automatisch migriert.
+- **Keine Breaking Changes**: Bestehende Sensoren und historische Daten bleiben unverändert.
+- **Firmware**: Getestet mit Enpal Firmware Solar Rel. **8.50.1-773465 (27.05.2026)**.
+
+---
+
+## 🙏 Feedback erwünscht
+
+Diese Beta lebt von eurem Feedback. Besonders interessiert mich:
+
+- 🅿️ Wird der **Wallbox-Status** jetzt korrekt angezeigt?
+- ✅ Was funktioniert gut? ❌ Was funktioniert nicht?
+
+Rückmeldungen bitte auf [GitHub Issues](https://github.com/derolli1976/enpal/issues) oder in den
+[GitHub Discussions](https://github.com/derolli1976/enpal/discussions).


### PR DESCRIPTION
## Description

Behebt die fehlerhafte Wallbox-Status-Erkennung und ergänzt einen Reparatur-Flow in Home Assistant.

- `WALLBOX_STATUS_SOURCE_CANDIDATES` (`const.py`) um die Namensvariante `wallbox_status_connector_1` erweitert. Manche Firmware-Stände (z.B. Enpal ArC GEN2) liefern den Rohsensor als `Status.Connector.1` statt `Status.Wallbox.Connector.1`. Über `friendly_name()` + `make_id()` ergibt das `wallbox_status_connector_1`, das bisher nicht erkannt wurde.
- Neue Reparatur-Meldung: Ist die Wallbox-Steuerung aktiv, liefert die Box Wallbox-Sensoren, aber kein Status-Source passt zur Auto-Erkennung, legt `sensor.py` `_manage_wallbox_status_issue()` ein behebbares Issue an. Die Meldung wird automatisch gelöscht, sobald die Quelle aufgelöst ist.
- Neuer `repairs.py` Fix-Flow: Über „Beheben" wählt der Nutzer den richtigen Wallbox-Sensor direkt aus (`get_wallbox_source_options`). Die Auswahl wird in die Option `wallbox_status_source` geschrieben, die Integration lädt neu.
- Übersetzungen für Issue und Fix-Flow in `de.json` und `en.json`.
- Version auf `2.9.9b4` angehoben (`manifest.json`), README, Release Notes und Copilot-Instructions aktualisiert.

## Motivation and Context

`sensor.wallbox_status` blieb auf manchen Boxen dauerhaft `unknown`, weil die
Auto-Erkennung nur einen von zwei firmware-abhängigen Sensornamen kannte. Im
HTML-Modus loggte `switch.py` zusätzlich alle 30 Sekunden eine Warnung. Der Fix
deckt beide Namensvarianten ab. Falls künftig ein weiterer unbekannter Name
auftritt, bleibt das Problem dank Reparatur-Meldung nicht verborgen, der Nutzer
kann die Quelle selbst zuweisen.

Fixes #127

## How Has This Been Tested?

- Vollständige Test-Suite lokal: `83 passed` (`pytest -q`, Python venv, `PYTHONPATH=e:\Github\enpal`).
- Statische Prüfung der geänderten Dateien ohne Fehler (`sensor.py`, `repairs.py`, `const.py`, `de.json`, `en.json`).
- Code-Review der Auto-Erkennung gegen die `make_id()`-Ableitung der betroffenen Firmware-Sensornamen (`Status.Connector.1` → `wallbox_status_connector_1`).

Testumgebung: Windows, Home Assistant Custom Component, Python-venv.

## Screenshots (if appropriate):

_n/a_

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.