### PR TITLE
Feature/firmware check

### DIFF
--- a/custom_components/enpal_webparser/config_flow.py
+++ b/custom_components/enpal_webparser/config_flow.py
@@ -196,6 +196,33 @@ def get_firmware_warning(hass, version: str | None) -> str:
     )
 
 
+def get_wallbox_addon_warning(hass, config: dict[str, Any]) -> str:
+    """Build a localized hint to disable the legacy wallbox add-on.
+
+    Shown when WebSocket mode is active together with wallbox control, because
+    in that case the integration controls the wallbox natively and the legacy
+    add-on ("App") would send duplicate commands. Returns an empty string when
+    the hint is not relevant.
+    """
+    if not config.get("use_wallbox"):
+        return ""
+    if config.get("data_source") != "websocket":
+        return ""
+
+    language = hass.config.language or "en"
+    if language == "de":
+        return (
+            "ℹ️ Hinweis: Du nutzt den WebSocket-Modus mit aktiver Wallbox-Steuerung. "
+            "Die Wallbox wird dann direkt gesteuert. Deaktiviere das alte Wallbox "
+            "Add-on (die \"App\"), damit keine doppelten Befehle gesendet werden."
+        )
+    return (
+        "ℹ️ Note: You are using WebSocket mode with wallbox control enabled. "
+        "The wallbox is controlled natively in this mode. Disable the legacy "
+        "wallbox add-on (the \"App\") to avoid sending duplicate commands."
+    )
+
+
 async def get_wallbox_source_options(hass, url: str) -> dict[str, str]:
     """Fetch the live Wallbox-group sensors and build selector options.
 
@@ -597,11 +624,15 @@ class EnpalOptionsFlowHandler(config_entries.OptionsFlow):
         firmware_version = await get_firmware_version(self.hass, config["url"])
         firmware_warning = get_firmware_warning(self.hass, firmware_version)
 
+        # Hint to disable the legacy wallbox add-on in WebSocket + wallbox mode.
+        wallbox_addon_warning = get_wallbox_addon_warning(self.hass, config)
+
         return self.async_show_form(
             step_id="init",
             data_schema=get_form_schema(config, wallbox_sources),
             errors=errors,
             description_placeholders={
                 "firmware_warning": firmware_warning,
+                "wallbox_addon_warning": wallbox_addon_warning,
             },
         )

--- a/custom_components/enpal_webparser/config_flow.py
+++ b/custom_components/enpal_webparser/config_flow.py
@@ -30,7 +30,12 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .discovery import discover_enpal_devices, quick_discover_enpal_devices
 from .wallbox_api import WallboxApiClient
-from .utils import make_id, parse_enpal_html_sensors
+from .utils import (
+    firmware_supports_websocket,
+    make_id,
+    parse_enpal_html_sensors,
+    parse_firmware_version,
+)
 from .const import (
     DEFAULT_GROUPS,
     DEFAULT_INTERVAL,
@@ -40,6 +45,7 @@ from .const import (
     DOMAIN,
     WALLBOX_MODE_SOURCE_CANDIDATES,
     WALLBOX_STATUS_SOURCE_CANDIDATES,
+    WEBSOCKET_MIN_FIRMWARE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -140,6 +146,54 @@ def get_default_config(options: dict[str, Any] | None = None) -> dict[str, Any]:
         "wallbox_mode_source": src.get("wallbox_mode_source", "auto"),
         "wallbox_status_source": src.get("wallbox_status_source", "auto"),
     }
+
+
+async def get_firmware_version(hass, url: str) -> str | None:
+    """Fetch the deviceMessages page and extract the Enpal firmware version.
+
+    Returns the dotted version string (e.g. "8.46.4") or None if the box is
+    unreachable or the version could not be parsed.
+    """
+    try:
+        session = async_get_clientsession(hass)
+        async with session.get(url, timeout=30) as response:
+            if response.status != 200:
+                return None
+            html = await response.text()
+        version = parse_firmware_version(html)
+        _LOGGER.debug("[Enpal] Detected firmware version: %s", version)
+        return version
+    except Exception as e:
+        _LOGGER.debug("[Enpal] Could not fetch firmware version: %s", e)
+        return None
+
+
+def get_firmware_warning(hass, version: str | None) -> str:
+    """Build a localized warning when firmware is too old for WebSocket mode.
+
+    Returns an empty string when the firmware is new enough or could not be
+    determined, so the message can always be passed as a placeholder.
+    """
+    capable = firmware_supports_websocket(version, WEBSOCKET_MIN_FIRMWARE)
+    if capable is not False:
+        return ""
+
+    min_version = f"{WEBSOCKET_MIN_FIRMWARE[0]}.{WEBSOCKET_MIN_FIRMWARE[1]}"
+    language = hass.config.language or "en"
+    if language == "de":
+        return (
+            f"⚠️ Achtung: Die erkannte Firmware deiner Enpal Box ist {version}. "
+            f"Der WebSocket-Modus benötigt Firmware {min_version} oder neuer. "
+            "Aktiviere den WebSocket-Modus nur, wenn deine Box mindestens diese "
+            "Firmware hat, sonst funktioniert er wahrscheinlich nicht. "
+            "Nutze in diesem Fall den HTML-Modus."
+        )
+    return (
+        f"⚠️ Warning: The detected firmware of your Enpal box is {version}. "
+        f"WebSocket mode requires firmware {min_version} or newer. "
+        "Only enable WebSocket mode if your box has at least this firmware, "
+        "otherwise it will likely not work. Use HTML mode instead."
+    )
 
 
 async def get_wallbox_source_options(hass, url: str) -> dict[str, str]:
@@ -424,7 +478,12 @@ class EnpalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "use_wallbox": DEFAULT_USE_WALLBOX,
             "data_source": "auto",
         }
-        
+
+        # Detect firmware to warn the user before they enable WebSocket mode
+        # on a box that is too old (< 8.50).
+        firmware_version = await get_firmware_version(self.hass, config["url"])
+        firmware_warning = get_firmware_warning(self.hass, firmware_version)
+
         if user_input is not None and "interval" in user_input:
             # Final step - validate and create entry
             errors: dict[str, str] = {}
@@ -484,6 +543,7 @@ class EnpalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors=errors,
                 description_placeholders={
                     "url": self._url,
+                    "firmware_warning": firmware_warning,
                 },
             )
         
@@ -502,6 +562,7 @@ class EnpalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }),
             description_placeholders={
                 "url": self._url,
+                "firmware_warning": firmware_warning,
             },
         )
 
@@ -532,8 +593,15 @@ class EnpalOptionsFlowHandler(config_entries.OptionsFlow):
         if config.get("use_wallbox"):
             wallbox_sources = await get_wallbox_source_options(self.hass, config["url"])
 
+        # Detect firmware to warn before enabling WebSocket mode on old boxes.
+        firmware_version = await get_firmware_version(self.hass, config["url"])
+        firmware_warning = get_firmware_warning(self.hass, firmware_version)
+
         return self.async_show_form(
             step_id="init",
             data_schema=get_form_schema(config, wallbox_sources),
             errors=errors,
+            description_placeholders={
+                "firmware_warning": firmware_warning,
+            },
         )

--- a/custom_components/enpal_webparser/const.py
+++ b/custom_components/enpal_webparser/const.py
@@ -25,6 +25,11 @@ DEFAULT_URL = "http://192.168.1.1/deviceMessages"  # Placeholder - use discovery
 DEFAULT_INTERVAL = 60
 DEFAULT_TIMEOUT = 30
 
+# --- Firmware ---
+# Minimum Enpal firmware (major, minor) required for WebSocket mode and native
+# wallbox control (Solar Rel. 8.50). Older firmware only supports HTML polling.
+WEBSOCKET_MIN_FIRMWARE = (8, 50)
+
 DEFAULT_GROUPS = [
     "Wallbox",
     "Battery",

--- a/custom_components/enpal_webparser/tests/test_firmware.py
+++ b/custom_components/enpal_webparser/tests/test_firmware.py
@@ -1,0 +1,63 @@
+#
+# Tests for Enpal Webparser - firmware version detection
+#
+# Unit tests for parse_firmware_version and firmware_supports_websocket.
+#
+# To run: pytest custom_components/enpal_webparser/tests/test_firmware.py
+#
+
+from custom_components.enpal_webparser.utils import (
+    parse_firmware_version,
+    firmware_supports_websocket,
+)
+
+
+def test_parse_firmware_version_from_html_snippet():
+    """Version is extracted from the deviceMessages sidebar anchor text."""
+    html = (
+        '<a href="" class="nav-item"><span class="navbar-brand"></span>'
+        "Solar Rel. 8.46.4-355926 (21.05.2025)</a>"
+    )
+    assert parse_firmware_version(html) == "8.46.4"
+
+
+def test_parse_firmware_version_850():
+    html = "Solar Rel. 8.50.1-773465 (01.06.2026)"
+    assert parse_firmware_version(html) == "8.50.1"
+
+
+def test_parse_firmware_version_real_html(real_html):
+    """The bundled fixture exposes a parseable firmware version."""
+    version = parse_firmware_version(real_html)
+    assert version is not None
+    assert version.startswith("8.")
+
+
+def test_parse_firmware_version_missing():
+    assert parse_firmware_version("") is None
+    assert parse_firmware_version(None) is None
+    assert parse_firmware_version("<html>no version here</html>") is None
+
+
+def test_firmware_supports_websocket_true():
+    assert firmware_supports_websocket("8.50") is True
+    assert firmware_supports_websocket("8.50.1-773465".split("-")[0]) is True
+    assert firmware_supports_websocket("8.51.0") is True
+    assert firmware_supports_websocket("9.0.0") is True
+
+
+def test_firmware_supports_websocket_false():
+    assert firmware_supports_websocket("8.46.4") is False
+    assert firmware_supports_websocket("8.49") is False
+    assert firmware_supports_websocket("7.99.9") is False
+
+
+def test_firmware_supports_websocket_unknown():
+    assert firmware_supports_websocket(None) is None
+    assert firmware_supports_websocket("") is None
+    assert firmware_supports_websocket("not-a-version") is None
+
+
+def test_firmware_supports_websocket_custom_minimum():
+    assert firmware_supports_websocket("8.46", min_version=(8, 40)) is True
+    assert firmware_supports_websocket("8.30", min_version=(8, 40)) is False

--- a/custom_components/enpal_webparser/translations/de.json
+++ b/custom_components/enpal_webparser/translations/de.json
@@ -47,7 +47,7 @@
     "step": {
       "init": {
         "title": "Optionen anpassen",
-        "description": "Hier kannst du zusätzliche Einstellungen vornehmen\n\n{firmware_warning}",
+        "description": "Hier kannst du zusätzliche Einstellungen vornehmen\n\n{firmware_warning}\n\n{wallbox_addon_warning}",
         "data": {
           "url": "URL / IP-Adresse der Enpal Box",
           "interval": "Abfrageintervall (in Sekunden) - Weniger als 60 Sekunden wird nicht empfohlen!",

--- a/custom_components/enpal_webparser/translations/de.json
+++ b/custom_components/enpal_webparser/translations/de.json
@@ -24,7 +24,7 @@
       },
       "configure": {
         "title": "Enpal Integration konfigurieren",
-        "description": "Einstellungen für Gerät konfigurieren: {url}",
+        "description": "Einstellungen für Gerät konfigurieren: {url}\n\n{firmware_warning}",
         "data": {
           "interval": "Abfrageintervall (in Sekunden) - Weniger als 60 Sekunden wird nicht empfohlen!",
           "timeout": "HTTP-Timeout (in Sekunden, 10-120) - Erhöhen, wenn Sensoren häufig als nicht verfügbar angezeigt werden",
@@ -47,7 +47,7 @@
     "step": {
       "init": {
         "title": "Optionen anpassen",
-        "description": "Hier kannst du zusätzliche Einstellungen vornehmen",
+        "description": "Hier kannst du zusätzliche Einstellungen vornehmen\n\n{firmware_warning}",
         "data": {
           "url": "URL / IP-Adresse der Enpal Box",
           "interval": "Abfrageintervall (in Sekunden) - Weniger als 60 Sekunden wird nicht empfohlen!",

--- a/custom_components/enpal_webparser/translations/en.json
+++ b/custom_components/enpal_webparser/translations/en.json
@@ -24,7 +24,7 @@
       },
       "configure": {
         "title": "Configure Enpal Integration",
-        "description": "Configure settings for device at: {url}",
+        "description": "Configure settings for device at: {url}\n\n{firmware_warning}",
         "data": {
           "interval": "Polling interval (in seconds) - Intervals below 60 seconds are not recommended!",
           "timeout": "HTTP timeout (in seconds, 10-120) - Increase if sensors frequently become unavailable",
@@ -47,7 +47,7 @@
     "step": {
       "init": {
         "title": "Adjust Options",
-        "description": "Here you can configure additional settings",
+        "description": "Here you can configure additional settings\n\n{firmware_warning}",
         "data": {
           "url": "URL / IP address of the Enpal Box",
           "interval": "Polling interval (in seconds) - Intervals below 60 seconds are not recommended!",

--- a/custom_components/enpal_webparser/translations/en.json
+++ b/custom_components/enpal_webparser/translations/en.json
@@ -47,7 +47,7 @@
     "step": {
       "init": {
         "title": "Adjust Options",
-        "description": "Here you can configure additional settings\n\n{firmware_warning}",
+        "description": "Here you can configure additional settings\n\n{firmware_warning}\n\n{wallbox_addon_warning}",
         "data": {
           "url": "URL / IP address of the Enpal Box",
           "interval": "Polling interval (in seconds) - Intervals below 60 seconds are not recommended!",

--- a/custom_components/enpal_webparser/utils.py
+++ b/custom_components/enpal_webparser/utils.py
@@ -126,6 +126,47 @@ def make_id(name: str) -> str:
     return name.strip("_")
 
 
+# Matches the firmware string in the deviceMessages page sidebar, e.g.
+# "Solar Rel. 8.46.4-355926 (21.05.2025)" -> "8.46.4"
+FIRMWARE_VERSION_RE = re.compile(
+    r"Solar\s+Rel\.\s*([0-9]+(?:\.[0-9]+)*)",
+    re.IGNORECASE,
+)
+
+
+def parse_firmware_version(html: Optional[str]) -> Optional[str]:
+    """Extract the Enpal firmware version from the deviceMessages HTML.
+
+    Returns the dotted version string (e.g. "8.46.4") or None if not found.
+    """
+    if not html:
+        return None
+    match = FIRMWARE_VERSION_RE.search(html)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def firmware_supports_websocket(
+    version: Optional[str],
+    min_version: Tuple[int, int] = (8, 50),
+) -> Optional[bool]:
+    """Check whether a firmware version supports WebSocket mode.
+
+    Compares the (major, minor) part of ``version`` against ``min_version``.
+    Returns True/False, or None if the version could not be parsed.
+    """
+    if not version:
+        return None
+    parts = version.split(".")
+    try:
+        major = int(parts[0])
+        minor = int(parts[1]) if len(parts) > 1 else 0
+    except (ValueError, IndexError):
+        return None
+    return (major, minor) >= min_version
+
+
 def is_strict_number(s: str) -> bool:
     s2 = s.strip().replace(',', '.')
     return bool(re.fullmatch(r'[-+]?\d+(\.\d+)?', s2))


### PR DESCRIPTION
# Firmware-Check (>= 8.50) mit Warnhinweisen im Config- und Options-Flow

## Description
Diese Änderung liest die Firmware-Version der Enpal Box aus dem Quelltext der `deviceMessages`-Seite (z. B. `Solar Rel. 8.46.4-355926`) und blendet im Config- und Options-Flow Hinweise ein:

- Neue Konstante `WEBSOCKET_MIN_FIRMWARE = (8, 50)` in `const.py`.
- Neue Helper in `utils.py`: `parse_firmware_version()` extrahiert die dotted Version, `firmware_supports_websocket()` vergleicht Major/Minor gegen die Mindestversion (gibt `None` zurück, wenn die Version unbekannt ist).
- Im Config-Flow (Configure-Step) und Options-Flow holt `get_firmware_version()` die Seite und `get_firmware_warning()` baut einen lokalisierten Warnhinweis (de/en), wenn die Firmware sicher unter 8.50 liegt. So wird verhindert, dass der WebSocket-Modus auf zu alter Firmware aktiviert wird.
- Zusätzlicher Hinweis `get_wallbox_addon_warning()` im Options-Flow: Bei `data_source = websocket` und aktiver Wallbox-Steuerung wird empfohlen, das Legacy-Wallbox-Add-on (die "App") zu deaktivieren, damit keine doppelten Befehle gesendet werden.
- Translations (`de.json`, `en.json`) um die Placeholder `{firmware_warning}` und `{wallbox_addon_warning}` ergänzt.

Die Hinweise erscheinen nur, wenn sie relevant sind. Ist die Box nicht erreichbar oder die Version nicht lesbar, bleiben die Placeholder leer (kein Fehlalarm).

## Motivation and Context
Der WebSocket-Modus und die native Wallbox-Steuerung benötigen Enpal Firmware Solar Rel. 8.50. Auf älterer Firmware funktioniert der WebSocket-Modus wahrscheinlich nicht korrekt. Ohne Warnung könnten Nutzer den Modus aktivieren und eine nicht funktionierende Integration erhalten. Der Firmware-Check und die Hinweise machen die Voraussetzung transparent. Der zusätzliche Wallbox-Add-on-Hinweis verhindert doppelte Steuerbefehle beim Wechsel von HTML auf WebSocket mit aktiver Wallbox.

## How Has This Been Tested?
- Neue Unit-Tests in `custom_components/enpal_webparser/tests/test_firmware.py` decken `parse_firmware_version()` (HTML-Snippet, 8.50, reale Fixture, fehlende/ungültige Version) und `firmware_supports_websocket()` (true/false/unknown, eigene Mindestversion) ab.
- Lokal ausgeführt mit:

  ```pwsh
  $env:PYTHONPATH = "e:\Github\enpal"; pytest -q
  ```

- Ergebnis: 91 Tests bestanden (inkl. 8 neuer Firmware-Tests), keine Regressionen.
- Umgebung: Windows, Python venv im Projekt, Home Assistant Test-Dependencies.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.