### PR TITLE
Release 3.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Details in den [Release Notes 3.0.0](docs/RELEASE_NOTES_3.0.0.md).
 
 > **Update 3.0.1:** Bugfix für den WebSocket-Modus. Sensoren, die direkt nach einem Neustart fehlten, froren ein oder blieben `unavailable`. Details in den [Release Notes 3.0.1](docs/RELEASE_NOTES_3.0.1.md).
 
+> **Update 3.0.2:** Geringere CPU-Last und ein Statussensor der Wallbox, der nicht mehr fehlerhaft als Spannungssensor behandelt wird. Details in den [Release Notes 3.0.2](docs/RELEASE_NOTES_3.0.2.md).
+
 > **Hinweis zur Firmware:** Der WebSocket-Modus, die native Wallbox-Steuerung und das RenderBatch-Parsing setzen die Enpal-Firmware **Solar Rel. 8.50.1-773465 (27.05.2026)** voraus. Auf älteren Firmware-Ständen läuft weiterhin der HTML-Polling-Modus (Legacy), ohne die neuen Echtzeit- und Wallbox-Funktionen.
 
 > **Hinweis zu fehlenden Sensoren:** Seit Firmware **8.50** stellt Enpal einige Sensoren nicht mehr bereit. Die Integration kann das nicht ändern. Betroffene Entitäten kannst du in Home Assistant gefahrlos löschen.

--- a/custom_components/enpal_webparser/manifest.json
+++ b/custom_components/enpal_webparser/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/derolli1976/enpal/issues",
   "requirements": ["beautifulsoup4", "psutil"],
-  "version": "3.0.1"
+  "version": "3.0.2"
 }

--- a/custom_components/enpal_webparser/tests/test_utils.py
+++ b/custom_components/enpal_webparser/tests/test_utils.py
@@ -49,6 +49,12 @@ def test_get_class_and_unit():
     unit, device_class = get_class_and_unit("17 bananas", UNIT_DEVICE_CLASS_MAP)
     assert unit is None
     assert device_class is None
+    # Status strings that happen to end with a unit letter must NOT be detected
+    # as numeric sensors (e.g. "SuspendedEV" ends with "V" -> voltage).
+    for status in ("SuspendedEV", "Unknown", "Available", "Charging"):
+        unit, device_class = get_class_and_unit(status, UNIT_DEVICE_CLASS_MAP)
+        assert unit is None, status
+        assert device_class is None, status
 
 def test_normalize_value_and_unit():
     """Test that normalize_value_and_unit converts Wh to kWh, handles default units, and leaves correct values."""

--- a/custom_components/enpal_webparser/utils.py
+++ b/custom_components/enpal_webparser/utils.py
@@ -19,6 +19,7 @@
 import logging
 import re
 from datetime import datetime
+from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple
 
 from bs4 import BeautifulSoup, Tag
@@ -119,8 +120,14 @@ def expand_inverter_system_state(group: str, raw_text: str, timestamp_iso: Optio
     return out
 
 
+@lru_cache(maxsize=4096)
 def make_id(name: str) -> str:
-    """Generate a Home Assistant-friendly unique id from a name."""
+    """Generate a Home Assistant-friendly unique id from a name.
+
+    Result is cached because this is called very frequently (for every sensor
+    on every coordinator update) and the set of input names is small and
+    bounded by the sensors the Enpal box exposes.
+    """
     name = name.lower()
     name = re.sub(r"[^\w]+", "_", name)
     return name.strip("_")

--- a/custom_components/enpal_webparser/utils.py
+++ b/custom_components/enpal_webparser/utils.py
@@ -206,7 +206,12 @@ def get_class_and_unit(
     value = value.strip()
     for unit, device_class in unit_device_class_map.items():
         if value.endswith(unit):
-            return unit, device_class
+            # Only treat the trailing characters as a unit if the part in front
+            # of it is actually numeric. Otherwise status strings like
+            # "SuspendedEV" (ends with "V") would be misread as a voltage value.
+            prefix = value[: len(value) - len(unit)].strip()
+            if prefix and is_strict_number(prefix):
+                return unit, device_class
     return None, None
 
 

--- a/docs/RELEASE_NOTES_3.0.2.md
+++ b/docs/RELEASE_NOTES_3.0.2.md
@@ -1,0 +1,43 @@
+# 3.0.2 - Geringere CPU-Last und korrekter Wallbox-Statussensor
+
+3.0.2 ist ein Bugfix-Release. Es senkt die CPU-Last der Integration und behebt einen Fehler, bei dem ein Wallbox-Statussensor fälschlich als Spannungssensor behandelt wurde. Danke an alle, die das gemeldet und beim Eingrenzen geholfen haben.
+
+Es sind keine Einrichtungsschritte nötig. Bestehende Einstellungen bleiben erhalten.
+
+---
+
+## 🐛 Behobene Fehler
+
+### Höhere CPU-Last seit 3.0.0
+
+Bei jedem Datenabgleich hat jede Entität die komplette Sensorliste durchsucht und dabei für jeden Eintrag die ID neu berechnet. Die ID-Berechnung lief so sehr oft pro Sekunde, vor allem im WebSocket-Modus mit vielen Sensoren. Das hat unnötig CPU-Last erzeugt.
+
+Die ID-Berechnung wird jetzt zwischengespeichert. Wiederholte Aufrufe für denselben Namen kosten kaum noch Rechenzeit. Die Sensorwerte ändern sich dadurch nicht.
+
+### Wallbox-Statussensor als Spannungssensor erkannt
+
+Der Statussensor `Status.Connector.1` liefert Textwerte wie `SuspendedEV`, `Charging` oder `Unknown`. Die Einheitenerkennung hat das Schluss-`V` von `SuspendedEV` als Volt gelesen und den Sensor als Spannung mit Einheit `V` eingestuft. Home Assistant hat den Textwert dann abgelehnt und bei jedem Update einen Fehler geworfen.
+
+Eine Einheit wird jetzt nur noch erkannt, wenn der Teil davor eine Zahl ist. Textwerte wie `SuspendedEV` bleiben einfache Textsensoren. Echte Messwerte wie `230 V` oder `1234 kWh` werden weiterhin korrekt eingeordnet.
+
+---
+
+## 🔧 Installation und Upgrade
+
+### Über HACS:
+1. In HACS → **Enpal Solar** öffnen
+2. Auf die **drei Punkte** (⋮) klicken → **Version auswählen**
+3. Version **3.0.2** auswählen und installieren
+4. Home Assistant **neu starten**
+
+### Bestehende Installation upgraden:
+1. Vor dem Upgrade ein **Home Assistant-Backup** anlegen.
+2. Version **3.0.2** über HACS installieren (siehe oben).
+3. Home Assistant **neu starten**.
+4. Bestehende Einstellungen bleiben erhalten.
+
+---
+
+## 🔌 Firmware-Hinweis
+
+Die WebSocket-Funktionen setzen weiterhin die Enpal-Firmware **Solar Rel. 8.50** voraus. Auf älteren Firmware-Ständen läuft der HTML-Polling-Modus (Legacy) unverändert. Details zu den Funktionen aus dem letzten großen Release stehen in den [Release Notes 3.0.0](RELEASE_NOTES_3.0.0.md).


### PR DESCRIPTION
## Release 3.0.2

Bugfix-Release. Senkt die CPU-Last der Integration und behebt einen falsch klassifizierten Wallbox-Statussensor. Keine Einrichtungsschritte nötig, bestehende Einstellungen bleiben erhalten.

Vollständige Release Notes: [docs/RELEASE_NOTES_3.0.2.md](docs/RELEASE_NOTES_3.0.2.md)

### Behobene Fehler

- **Höhere CPU-Last seit 3.0.0 (#137):** `make_id()` wurde pro Datenabgleich sehr oft aufgerufen (jede Entität durchsucht die komplette Sensorliste). Die ID-Berechnung wird jetzt per `lru_cache` zwischengespeichert. Verhalten und Werte bleiben unverändert.
- **Wallbox-Statussensor als Spannungssensor erkannt:** Textwerte wie `SuspendedEV` (endet auf `V`) wurden als Volt eingestuft, woraufhin Home Assistant bei jedem Update einen `ValueError` warf. Eine Einheit wird jetzt nur noch erkannt, wenn der Teil davor numerisch ist.

### Änderungen

- `version` in `manifest.json` auf `3.0.2` gesetzt
- Release Notes `docs/RELEASE_NOTES_3.0.2.md` ergänzt
- Update-Hinweis in `README.md` ergänzt

### Enthaltene Merges auf dev
- #140 (CPU-Last / `make_id`-Caching, Issue #137)
- #139 (Wallbox-Statussensor / `get_class_and_unit`)
