### PR TITLE
Fix #144: msgpack zu manifest.json hinzufügen (HA Core venv)

### DIFF
--- a/custom_components/enpal_webparser/manifest.json
+++ b/custom_components/enpal_webparser/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/derolli1976/enpal",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/derolli1976/enpal/issues",
-  "requirements": ["beautifulsoup4", "psutil"],
+  "requirements": ["beautifulsoup4", "psutil", "msgpack>=1.0.7"],
   "version": "3.0.2"
 }


### PR DESCRIPTION
Behebt #144.

Ab Version 3 nutzt die Integration im WebSocket-Modus (Firmware 8.50) das MessagePack-Protokoll und damit das Paket `msgpack`. Es war bisher nicht in den `requirements` der `manifest.json` deklariert.

Bei HA OS/Container/Supervised ist `msgpack` ohnehin vorhanden. Bei HA Core im venv installiert HA für Custom-Integrationen nur die im Manifest deklarierten Pakete, daher schlug der Import von `enpal_webparser.sensor` mit `ModuleNotFoundError` fehl (`enpal_webparser.sensor not found`).

Fix: `msgpack>=1.0.7` zu den Manifest-Requirements hinzugefügt.