### PR TITLE
fix: Sensorauslesung für Enpal-Firmware 8.51

### DIFF
--- a/custom_components/enpal_webparser/api/websocket_client.py
+++ b/custom_components/enpal_webparser/api/websocket_client.py
@@ -430,14 +430,15 @@ class EnpalWebSocketClient(EnpalApiClient):
             normalize_value_and_unit,
             is_strict_number,
         )
-        from ..const import UNIT_DEVICE_CLASS_MAP, DEFAULT_UNITS
+        from ..const import UNIT_DEVICE_CLASS_MAP, DEFAULT_UNITS, SENSOR_KEY_ALIASES
 
         patched = 0
         for row in rows:
             value = row.get("value")
             if not is_patchable_value(value):
                 continue
-            indices = self._key_index.get(make_id(row["key"]))
+            key = SENSOR_KEY_ALIASES.get(row["key"], row["key"])
+            indices = self._key_index.get(make_id(key))
             # Skip unknown keys (new sensors) and ambiguous cross-group keys;
             # the periodic full scrape handles those correctly.
             if not indices or len(indices) != 1:

--- a/custom_components/enpal_webparser/const.py
+++ b/custom_components/enpal_webparser/const.py
@@ -113,6 +113,22 @@ WALLBOX_STATUS_SOURCE_CANDIDATES = [
     "wallbox_status_connector_1",
 ]
 
+# --- Sensor key aliases (firmware 8.51) ---
+# Firmware 8.51 appended an ".Inverter" suffix to several data points in the
+# "Inverter" group. Mapping them back to the previous key keeps the existing
+# entity ids, history and automations intact instead of creating duplicates.
+SENSOR_KEY_ALIASES = {
+    "Energy.Battery.Charge.Day.Inverter": "Energy.Battery.Charge.Day",
+    "Energy.Battery.Discharge.Day.Inverter": "Energy.Battery.Discharge.Day",
+    "Mode.Forcible.Charge.Discharge.Inverter": "Mode.Forcible.Charge.Discharge",
+    "Power.AC.Phase.A.Inverter": "Power.AC.Phase.A",
+    "Power.AC.Phase.B.Inverter": "Power.AC.Phase.B",
+    "Power.AC.Phase.C.Inverter": "Power.AC.Phase.C",
+    "Power.Battery.Charge.Discharge.Inverter": "Power.Battery.Charge.Discharge",
+    "Power.Battery.Charge.Max.Inverter": "Power.Battery.Charge.Max",
+    "Power.Battery.Discharge.Max.Inverter": "Power.Battery.Discharge.Max",
+}
+
 # --- Date/Time Formats ---
 ENPAL_TIMESTAMP_FORMAT = "%m/%d/%Y %H:%M:%S"
 

--- a/custom_components/enpal_webparser/tests/conftest.py
+++ b/custom_components/enpal_webparser/tests/conftest.py
@@ -6,3 +6,11 @@ def real_html():
     fixture_path = Path(__file__).parent / "fixtures" / "deviceMessages.html"
     with fixture_path.open("r", encoding="utf-8") as f:
         return f.read()
+
+
+@pytest.fixture
+def real_html_851():
+    """deviceMessages page of Enpal firmware 8.51 (extra "Notes" column)."""
+    fixture_path = Path(__file__).parent / "fixtures" / "deviceMessages851.html"
+    with fixture_path.open("r", encoding="utf-8") as f:
+        return f.read()

--- a/custom_components/enpal_webparser/tests/fixtures/deviceMessages851.html
+++ b/custom_components/enpal_webparser/tests/fixtures/deviceMessages851.html
@@ -1,19 +1,21 @@
 <!DOCTYPE html>
 <html><head><title>Device Messages</title></head>
 <body>
-<p>Solar Rel. 8.51.0-950631 (28.07.2026)</p>
+<p>Solar Rel. 8.51.0-955735 (30.07.2026)</p>
 <div class="card mb-4"><!--!--><div class="card-header"><h2>Site Data</h2></div>
 <div class="card-body"><!--!--><!--!-->
 <table class="table table-bordered table-striped"><!--!--><thead><tr><th class="col-3">Sensor Name</th>
 <th class="col-3">Value</th>
 <th class="col-3">Timestamp</th></tr></thead>
-<tbody><tr class="dp-flash"><td>Energy.Consumption.Total.Day</td><!--!-->
-<td><!--!-->17.8kWh</td><!--!-->
-<td>2026-07-29 14:22:05.600Z</td></tr><tr class=""><td>Energy.Consumption.Total.Lifetime</td><!--!-->
-<td><!--!-->31036.1kWh</td><!--!-->
-<td>2026-07-29 14:11:21.645Z<!--!--><span class="m-3" style="color: orange" title="This data is more than 5 minutes old">⚠️</span></td></tr><tr class="dp-flash"><td>Power.Consumption.Total</td><!--!-->
-<td><!--!-->0W</td><!--!-->
-<td>2026-07-29 14:22:03.943Z</td></tr></tbody></table></div></div>
+<tbody><tr class=""><td>Energy.Consumption.Total.Day</td><!--!-->
+<td><!--!-->6.15kWh</td><!--!-->
+<td>2026-07-31 06:38:38.870Z</td></tr><tr class=""><td>Energy.Consumption.Total.Lifetime</td><!--!-->
+<td><!--!-->31076.22kWh</td><!--!-->
+<td>2026-07-31 06:32:38.002Z<!--!--><span class="m-3" style="color: orange" title="This data is more than 5 minutes old">⚠️</span></td></tr><tr class=""><td>Power.Consumption.AC</td><!--!-->
+<td><!--!-->827W</td><!--!-->
+<td>2026-07-31 06:27:09.622Z<!--!--><span class="m-3" style="color: orange" title="This data is more than 5 minutes old">⚠️</span></td></tr><tr class=""><td>Power.Consumption.Total</td><!--!-->
+<td><!--!-->819.7W</td><!--!-->
+<td>2026-07-31 06:38:38.915Z</td></tr></tbody></table></div></div>
 <div class="card mb-4"><div class="card-header d-flex justify-content-between align-items-center"><div><h2>Battery</h2><!--!-->
 <span>HuaweiDongleBattery</span></div><div><div class="form-check"><input class="form-check-input" id="showUnsupported_Battery" type="checkbox"/><!--!-->
 <label class="form-check-label" for="showUnsupported_Battery"><!--!-->
@@ -29,7 +31,11 @@
 <th class="col-3 text-center" rowspan="2">Notes</th></tr>
 <tr><th class="col-3 text-center">Value</th>
 <th class="text-nowrap text-center" style="width: 1%;">Received at</th></tr></thead>
-<tbody><tr class="pi-row-error"><td>Power.AC.Max.Battery</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: The value has been cleared.</span></td></tr><tr class="pi-row-error"><td>SerialNumber.Battery.Unit.1</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: The value has been cleared.</span></td></tr><tr class="pi-row-error"><td>SerialNumber.Battery.Unit.2</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: The value has been cleared.</span></td></tr></tbody></table></div></div>
+<tbody><tr class=""><td>Power.AC.Max.Battery</td><td><!--!-->5000W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:32:53.46</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>SerialNumber.Battery.Unit.1</td><td>HV0000000000</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">05:52:30.99</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash pi-row-validation"><td>SerialNumber.Battery.Unit.2</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">invalid: SerialNumber.Battery.Unit.2 contains invalid characters ; SerialNumber.Battery.Unit.2 had a value which was invalid: </span></td></tr></tbody></table></div></div>
 <div class="card mb-4"><div class="card-header d-flex justify-content-between align-items-center"><div><h2>IoTEdgeDevice</h2><!--!-->
 <span>IoTEdgeDevice</span></div><div><div class="form-check"><input class="form-check-input" id="showUnsupported_IoTEdgeDevice" type="checkbox"/><!--!-->
 <label class="form-check-label" for="showUnsupported_IoTEdgeDevice"><!--!-->
@@ -46,41 +52,41 @@
 <tr><th class="col-3 text-center">Value</th>
 <th class="text-nowrap text-center" style="width: 1%;">Received at</th></tr></thead>
 <tbody><tr class="dp-flash pi-row-validation"><td>Cpu.Load</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">invalid: Cpu.Load unit type is incorrect. Expected: None, Value: Percent</span></td></tr><tr class=""><td>Device.Name</td><td>test-device</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:08:28.29</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">2026-07-30 14:05:38.91</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Generation.HW</td><td>1.0</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:09:10.41</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">2026-07-30 14:05:40.83</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Generation.SW</td><td>2.0</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:08:28.28</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">2026-07-30 14:05:38.91</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>HW.Cronny.Result</td><td>cronny.hw_metrics.ok</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:15.00</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>IoT.Data.Consumption.Lan.Down.Month</td><td><!--!-->26196</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:15.00</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>IoT.Data.Consumption.Lan.Up.Month</td><td><!--!-->7735</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:15.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:15.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>IoT.Data.Consumption.Lan.Down.Month</td><td><!--!-->27154</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:15.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>IoT.Data.Consumption.Lan.Up.Month</td><td><!--!-->8183</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:15.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>IoT.Data.Consumption.Lte.Down.Month</td><td><!--!-->0</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:08:55.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">2026-07-30 14:05:15.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>IoT.Data.Consumption.Lte.Up.Month</td><td><!--!-->0</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:08:55.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">2026-07-30 14:05:15.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>IoT.MainState</td><td>Operation</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:30.30</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:40.30</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>IoTEdgeDevice.Device.Type</td><td>imx8mmebcrs08a2</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:08:28.28</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">2026-07-30 14:05:38.91</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>IoTEdgeDevice.SerialNumber</td><td>0000000000000000000000000000dead</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:08:28.11</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemManagerErr.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemManagerErr.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemManagerErr.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemManagerErr.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkError.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkError.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkError.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkError.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorLowSignal.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorLowSignal.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorLowSignal.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorLowSignal.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorNoIp.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorNoIp.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorNoIp.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorNoIp.LastTime } has not been set</span></td></tr><tr class=""><td>LTE.CellularGuard.Result.Timestamp</td><td>2026-07-29T14:19:00Z</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:19:00.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">2026-07-30 14:05:38.84</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemManagerErr.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemManagerErr.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemManagerErr.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemManagerErr.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkError.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkError.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkError.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkError.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorLowSignal.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorLowSignal.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorLowSignal.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorLowSignal.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorNoIp.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorNoIp.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorNoIp.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorNoIp.LastTime } has not been set</span></td></tr><tr class=""><td>LTE.CellularGuard.Result.Timestamp</td><td>2026-07-31T06:37:07Z</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:37:07.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>LTE.CellularGuard.Result.Value</td><td>cg.modem_lsusb_no_info</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:19:00.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:37:07.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>LTE.CellularGuard.Result.Version</td><td>v6.3</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:19:00.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:37:07.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.SimError.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.SimError.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.SimError.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.SimError.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.SimError10.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.SimError10.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.SimError10.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.SimError10.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.Connection.Type</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: ConnectionType is not available</span></td></tr><tr class="dp-flash"><td>LTE.Cronny.Result</td><td>cronny.lte_signal.no_lte</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:15.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:35.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>LTE.Failover.Result</td><td>cronny.lte_failover.lan_only</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:20:09.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:35:05.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>LTE.Modem.Firmware.Version</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: ModemFirmwareVersion is not available</span></td></tr><tr class="pi-row-error"><td>LTE.Modem.Type</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: ModemType is not available</span></td></tr><tr class=""><td>LTE.Predictor.Id</td><td>GaussianNB_bandwidth_acceptable_20231014_091157</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:08:28.30</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">2026-07-30 14:05:38.92</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>LTE.Predictor.Result.Passed</td><td><!--!-->0</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:30.30</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:40.30</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>LTE.Quality</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Quality is not available</span></td></tr><tr class="pi-row-error"><td>LTE.RSRP</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: RSRP is not available</span></td></tr><tr class="pi-row-error"><td>LTE.RSRQ</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: RSRQ is not available</span></td></tr><tr class="pi-row-error"><td>LTE.RSSI</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: RSSI is not available</span></td></tr><tr class="pi-row-error"><td>LTE.SNR</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: SNR is not available</span></td></tr><tr class="pi-row-error"><td>LTE.State</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: State is not available</span></td></tr><tr class="dp-flash pi-row-validation"><td>Memory.Usage</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">invalid: Memory.Usage unit type is incorrect. Expected: None, Value: Percent</span></td></tr></tbody></table></div></div>
 <div class="card mb-4"><div class="card-header d-flex justify-content-between align-items-center"><div><h2>PowerSensor</h2><!--!-->
 <span>HuaweiPowerMeter</span></div><div><div class="form-check"><input class="form-check-input" id="showUnsupported_PowerSensor" type="checkbox"/><!--!-->
@@ -97,18 +103,18 @@
 <th class="col-3 text-center" rowspan="2">Notes</th></tr>
 <tr><th class="col-3 text-center">Value</th>
 <th class="text-nowrap text-center" style="width: 1%;">Received at</th></tr></thead>
-<tbody><tr class="pi-row-error"><td>Meter.Connect.State</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter.Connect.State } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter.Enable.Disable</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter.Enable.Disable } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Phase.A</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Phase.A } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Phase.B</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Phase.B } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Phase.C</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Phase.C } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Total</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Total } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.Connect.State</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.Connect.State } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.Enable.Disable</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.Enable.Disable } has not been set</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.A</td><td><!--!-->-3094W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.B</td><td><!--!-->-2691W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.C</td><td><!--!-->-2414W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>Power.Factor</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Power.Factor } has not been set</span></td></tr><tr class="pi-row-error"><td>Power.Reactive</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Power.Reactive } has not been set</span></td></tr><tr class="dp-flash"><td>Voltage.Phase.A</td><td><!--!-->236.6V</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:21:41.00</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Voltage.Phase.B</td><td><!--!-->234.5V</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:21:41.00</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Voltage.Phase.C</td><td><!--!-->234.8V</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:21:41.00</td><!--!-->
+<tbody><tr class="pi-row-error"><td>Meter.Connect.State</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter.Connect.State } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter.Enable.Disable</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter.Enable.Disable } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Phase.A</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Phase.A } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Phase.B</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Phase.B } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Phase.C</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Phase.C } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Total</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Total } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.Connect.State</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.Connect.State } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.Enable.Disable</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.Enable.Disable } has not been set</span></td></tr><tr class=""><td>Power.AC.Phase.A</td><td><!--!-->-218W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.87</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.AC.Phase.B</td><td><!--!-->476W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.87</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.AC.Phase.C</td><td><!--!-->-223W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.87</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash pi-row-validation"><td>Power.Factor</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">invalid: Power.Factor unit type is incorrect. Expected: Percent, Value: None</span></td></tr><tr class="dp-flash pi-row-validation"><td>Power.Reactive</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">invalid: Power.Reactive unit type is incorrect. Expected: kVAR, Value: kW</span></td></tr><tr class=""><td>Voltage.Phase.A</td><td><!--!-->231.8V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:35:39.90</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Voltage.Phase.B</td><td><!--!-->231.3V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:35:39.90</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Voltage.Phase.C</td><td><!--!-->231.3V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:35:39.90</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr></tbody></table></div></div>
 <div class="card mb-4"><div class="card-header d-flex justify-content-between align-items-center"><div><h2>Wallbox</h2><!--!-->
 <span>StarchargeWallbox</span></div><div><div class="form-check"><input class="form-check-input" id="showUnsupported_Wallbox" type="checkbox"/><!--!-->
@@ -126,47 +132,47 @@
 <tr><th class="col-3 text-center">Value</th>
 <th class="text-nowrap text-center" style="width: 1%;">Received at</th></tr></thead>
 <tbody><tr class="pi-row-error"><td>ChargeBox.SerialNumber</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = ChargeBox.SerialNumber } has not been set</span></td></tr><tr class=""><td>ChargePoint.SerialNumber</td><td>1000000001</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:10:10.67</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:13:17.23</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>ChargePoint.SerialNumber.Property</td><td>1000000001</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:10:10.67</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:13:17.23</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Count.Wallbox.Connector.1.Phases.Charging</td><td><!--!-->3</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:35.50</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Current.Wallbox.Connector.1.Phase.A</td><td><!--!-->0.01A</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Current.Wallbox.Connector.1.Phase.B</td><td><!--!-->0A</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Current.Wallbox.Connector.1.Phase.C</td><td><!--!-->0A</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Energy.Wallbox.Connector.1.Charged.Total</td><td><!--!-->12642330Wh</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:45.49</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Current.Wallbox.Connector.1.Phase.A</td><td><!--!-->0.01A</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:13.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Current.Wallbox.Connector.1.Phase.B</td><td><!--!-->0A</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:13.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Current.Wallbox.Connector.1.Phase.C</td><td><!--!-->0A</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:13.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Energy.Wallbox.Connector.1.Charged.Total</td><td><!--!-->12665760Wh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:13.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Mode.Charge.Connector.1</td><td>Fast</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:09:09.50</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.Wallbox.Connector.1.Charging</td><td><!--!-->2W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">2026-07-30 14:06:00.83</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.Wallbox.Connector.1.Charging</td><td><!--!-->2W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:13.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Power.Wallbox.Connector.1.Charging.Requested</td><td><!--!-->11000W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:20.50</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.Wallbox.Connector.1.Offered</td><td><!--!-->11209W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>State.Wallbox.Connector.1.Charge</td><td><!--!-->0%</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:40.51</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.Wallbox.Connector.1.Offered</td><td><!--!-->11000W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:13.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>State.Wallbox.Connector.1.Charge</td><td><!--!-->0%</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:13.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Status.Wallbox.Connected</td><td><!--!-->1</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:35.50</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:45.49</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Status.Wallbox.Connector.1</td><td>Preparing</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:10:24.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:28:17.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Version.SW.Wallbox</td><td>2.0.1.3.3b118</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:10:10.67</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Voltage.Wallbox.Connector.1.Phase.A</td><td><!--!-->236.5V</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Voltage.Wallbox.Connector.1.Phase.B</td><td><!--!-->235.4V</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Voltage.Wallbox.Connector.1.Phase.C</td><td><!--!-->235.2V</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:13:17.23</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Voltage.Wallbox.Connector.1.Phase.A</td><td><!--!-->231.5V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:13.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Voltage.Wallbox.Connector.1.Phase.B</td><td><!--!-->232.6V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:13.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Voltage.Wallbox.Connector.1.Phase.C</td><td><!--!-->231.6V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:13.00</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Wallbox.DeviceId</td><td>1000000001</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:10:10.67</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:13:17.23</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Wallbox.Settings.AutomaticChargeStatus.Connector.1</td><td>Off</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:20.50</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:39:40.51</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>Wallbox.Settings.GunLockStatus.Connector.1</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Wallbox.Settings.GunLockStatus.Connector.1 } has not been set</span></td></tr><tr class=""><td>Wallbox.Settings.MinimumChargeCurrent.Connector.1</td><td><!--!-->6A</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:08:37.37</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">2026-07-30 14:05:49.86</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr></tbody></table></div></div>
 <div class="card mb-4"><div class="card-header d-flex justify-content-between align-items-center"><div><h2>Inverter</h2><!--!-->
 <span>HuaweiDongleInverter</span></div><div><div class="form-check"><input class="form-check-input" id="showUnsupported_Inverter" type="checkbox"/><!--!-->
@@ -183,44 +189,58 @@
 <th class="col-3 text-center" rowspan="2">Notes</th></tr>
 <tr><th class="col-3 text-center">Value</th>
 <th class="text-nowrap text-center" style="width: 1%;">Received at</th></tr></thead>
-<tbody><tr class="dp-flash"><td>Energy.Battery.Charge.Day.Inverter</td><td><!--!-->10.69kWh</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:05.59</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Energy.Battery.Discharge.Day.Inverter</td><td><!--!-->7.76kWh</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:05.60</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Energy.Grid.Export.Day</td><td><!--!-->1.38kWh</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash pi-row-validation"><td>Energy.Grid.Export.Lifetime</td><td><!--!-->9354.59kWh</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:11:21.64</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">more recent value invalid: Time Current between values is too large. 674 Seconds.</span></td></tr><tr class="dp-flash"><td>Energy.Grid.Import.Day</td><td><!--!-->0kWh</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Energy.Grid.Import.Lifetime</td><td><!--!-->14089.4kWh</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:21:41.01</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Energy.Production.Total.Day</td><td><!--!-->22.11kWh</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:04.45</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Energy.Production.Total.Lifetime</td><td><!--!-->26608.26kWh</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:15:48.32</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>Inverter.Power.Total</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Inverter.Power.Total } has not been set</span></td></tr><tr class="pi-row-error"><td>Inverter.System.State</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Inverter.System.State } has not been set</span></td></tr><tr class="pi-row-error"><td>Mode.Forcible.Charge.Discharge.Inverter</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Mode.Forcible.Charge.Discharge.Inverter } has not been set</span></td></tr><tr class="pi-row-error"><td>Mode.Power.Active</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Mode.Power.Active } has not been set</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.A.Inverter</td><td><!--!-->-3094W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.B.Inverter</td><td><!--!-->-2691W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.C.Inverter</td><td><!--!-->-2414W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.Battery.Charge.Discharge.Inverter</td><td><!--!-->0W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:21:26.07</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>Power.Battery.Charge.Max.Inverter</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Power.Battery.Charge.Max.Inverter } has not been set</span></td></tr><tr class="pi-row-error"><td>Power.Battery.Discharge.Max.Inverter</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Power.Battery.Discharge.Max.Inverter } has not been set</span></td></tr><tr class="dp-flash"><td>Power.DC.Total</td><td><!--!-->4966W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:21:37.74</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Power.DC.Total.Huawei</td><td><!--!-->4966W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:21:37.74</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.Grid.Export</td><td><!--!-->8199W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Power.Grid.Export.Huawei</td><td><!--!-->8171W</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:21:41.00</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>Power.Grid.Maximum.Feed</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Power.Grid.Maximum.Feed } has not been set</span></td></tr><tr class="dp-flash"><td>State.AlarmCodes.1</td><td><!--!-->0</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:21:28.40</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>State.AlarmCodes.2</td><td><!--!-->0</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:21:28.40</td><!--!-->
-<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>State.AlarmCodes.3</td><td><!--!-->0</td><!--!-->
-<td class="text-nowrap" style="width: 1%;">14:21:28.40</td><!--!-->
+<tbody><tr class=""><td>Energy.Battery.Charge.Day.Inverter</td><td><!--!-->0.2kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:36:52.13</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Energy.Battery.Discharge.Day.Inverter</td><td><!--!-->3.02kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:36:52.13</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Energy.Grid.Export.Day</td><td><!--!-->0.03kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.87</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Energy.Grid.Export.Lifetime</td><td><!--!-->9363.33kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.81</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Energy.Grid.Import.Day</td><td><!--!-->0.15kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.87</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Energy.Grid.Import.Lifetime</td><td><!--!-->14089.92kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.81</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Energy.Production.Total.Day</td><td><!--!-->3.21kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:36:42.20</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Energy.Production.Total.Lifetime</td><td><!--!-->26647.11kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:32:16.27</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash pi-row-validation"><td>Inverter.Power.Total</td><td><!--!-->747W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:26:35.47</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">more recent value invalid: Time Current between values is too large. 790 Seconds.</span></td></tr><tr class="dp-flash pi-row-validation"><td>Inverter.System.State</td><td><!--!--><ul><li>Decimal: 6</li><li>Bits: 0000000110</li><li>Bit 0: Standby: <span style="color:red;">✗</span></li><li>Bit 1: Grid-connected: <span style="color:green;">✓</span></li><li>Bit 2: Grid-connected normally: <span style="color:green;">✓</span></li><li>Bit 3: Grid connection with derating due to power rationing: <span style="color:red;">✗</span></li><li>Bit 4: Grid connection with derating due to internal causes of the solar inverter: <span style="color:red;">✗</span></li><li>Bit 5: Normal stop: <span style="color:red;">✗</span></li><li>Bit 6: Stop due to faults: <span style="color:red;">✗</span></li><li>Bit 7: Stop due to power rationing: <span style="color:red;">✗</span></li><li>Bit 8: Shutdown: <span style="color:red;">✗</span></li><li>Bit 9: Spot check: <span style="color:red;">✗</span></li><li></li></ul></td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:28:49.75</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">more recent value invalid: Time Current between values is too large. 656 Seconds.</span></td></tr><tr class="dp-flash pi-row-validation"><td>Mode.Forcible.Charge.Discharge.Inverter</td><td><!--!-->0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:31:20.80</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">more recent value invalid: Time Current between values is too large. 505 Seconds.</span></td></tr><tr class=""><td>Mode.Power.Active</td><td><!--!-->Unlimited (default)  0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:32:00.20</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.AC.Phase.A.Inverter</td><td><!--!-->-218W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.87</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.AC.Phase.B.Inverter</td><td><!--!-->476W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.87</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.AC.Phase.C.Inverter</td><td><!--!-->-223W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.87</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.Battery.Charge.Discharge.Inverter</td><td><!--!-->3W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:26.09</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash pi-row-validation"><td>Power.Battery.Charge.Max.Inverter</td><td><!--!-->5000W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">03:26:01.94</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">more recent value invalid: Time Current between values is too large. 11624 Seconds.</span></td></tr><tr class="dp-flash pi-row-validation"><td>Power.Battery.Discharge.Max.Inverter</td><td><!--!-->5000W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">03:26:01.94</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">more recent value invalid: Time Current between values is too large. 11624 Seconds.</span></td></tr><tr class=""><td>Power.DC.Total</td><td><!--!-->787.7W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.91</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Power.DC.Total.Huawei</td><td><!--!-->768W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:36:32.57</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.Grid.Export</td><td><!--!-->-35W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:38.87</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Power.Grid.Export.Huawei</td><td><!--!-->-66W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:23.05</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.Grid.Maximum.Feed</td><td><!--!-->4662W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:38:43.05</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>State.AlarmCodes.1</td><td><!--!-->0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:36:32.08</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>State.AlarmCodes.2</td><td><!--!-->0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:36:32.09</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>State.AlarmCodes.3</td><td><!--!-->0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">06:36:32.09</td><!--!-->
 <td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr></tbody></table></div></div>
 <div class="card mb-4"><!--!--><div class="card-header"><h2>Averaged/interpolated VPP Values</h2></div>
 <div class="card-body"><!--!--><!--!-->
@@ -237,7 +257,7 @@
 <!--!--><!--!-->
 <!--!-->
 <!--!-->
-<div _bl_2a19aba8-0015-4329-bf98-e38c90675959="" class="rz-chart rz-scheme-pastel" id="3MjwVKpMoE"><!--!-->
+<div _bl_2020deb9-cef0-4147-8620-2a854aaa620e="" class="rz-chart rz-scheme-pastel" id="wypjndqnrE"><!--!-->
 <!--!--><!--!-->
 <!--!--> <div class="rz-legend rz-legend-right"><!--!-->
 <ul class="rz-legend-items"><!--!-->
@@ -247,8 +267,8 @@
 <svg style="width: 100%; height: 100%"><!--!-->
 <g transform="translate(0, 32)"><!--!-->
 <!--!--><defs><!--!-->
-<clippath id="clipPath3MjwVKpMoE"><!--!-->
-<path d="M 0 236 L 1056.4000244140625 236 L 1056.4000244140625 0 L 0 0"></path><!--!-->
+<clippath id="clipPathwypjndqnrE"><!--!-->
+<path d="M 0 236 L 1345.703125 236 L 1345.703125 0 L 0 0"></path><!--!-->
 </clippath><!--!-->
 </defs><!--!-->
 </g><!--!-->
@@ -267,7 +287,7 @@
 <!--!--><!--!-->
 <!--!-->
 <!--!-->
-<div _bl_a81b4613-b094-4ea9-bf8d-c1d018012997="" class="rz-chart rz-scheme-pastel" id="rnm-nnJzuU"><!--!-->
+<div _bl_3e286af6-ce10-486c-a4a2-92c6683c13af="" class="rz-chart rz-scheme-pastel" id="n7UlJG52w0"><!--!-->
 <!--!--><!--!-->
 <!--!--> <div class="rz-legend rz-legend-right"><!--!-->
 <ul class="rz-legend-items"><!--!-->
@@ -277,8 +297,8 @@
 <svg style="width: 100%; height: 100%"><!--!-->
 <g transform="translate(0, 32)"><!--!-->
 <!--!--><defs><!--!-->
-<clippath id="clipPathrnm-nnJzuU"><!--!-->
-<path d="M 0 236 L 1056.4000244140625 236 L 1056.4000244140625 0 L 0 0"></path><!--!-->
+<clippath id="clipPathn7UlJG52w0"><!--!-->
+<path d="M 0 236 L 1345.703125 236 L 1345.703125 0 L 0 0"></path><!--!-->
 </clippath><!--!-->
 </defs><!--!-->
 </g><!--!-->
@@ -297,7 +317,7 @@
 <!--!--><!--!-->
 <!--!-->
 <!--!-->
-<div _bl_f6d638e3-e77e-4f6d-9e36-c30f30773ea8="" class="rz-chart rz-scheme-pastel" id="lpx9yzGrkE"><!--!-->
+<div _bl_b0625968-c577-4bcd-b9e3-0d42909d64e7="" class="rz-chart rz-scheme-pastel" id="uj5Tr9Bjr0"><!--!-->
 <!--!--><!--!-->
 <!--!--> <div class="rz-legend rz-legend-right"><!--!-->
 <ul class="rz-legend-items"><!--!-->
@@ -307,8 +327,8 @@
 <svg style="width: 100%; height: 100%"><!--!-->
 <g transform="translate(0, 32)"><!--!-->
 <!--!--><defs><!--!-->
-<clippath id="clipPathlpx9yzGrkE"><!--!-->
-<path d="M 0 236 L 1056.4000244140625 236 L 1056.4000244140625 0 L 0 0"></path><!--!-->
+<clippath id="clipPathuj5Tr9Bjr0"><!--!-->
+<path d="M 0 236 L 1345.703125 236 L 1345.703125 0 L 0 0"></path><!--!-->
 </clippath><!--!-->
 </defs><!--!-->
 </g><!--!-->
@@ -323,7 +343,5 @@
 <table class="table table-bordered table-striped"><!--!--><thead><tr><th class="col-3">Sensor Name</th>
 <th class="col-3">Value</th>
 <th class="col-3">Timestamp</th></tr></thead>
-<tbody><tr class=""><td>Current.Phase.B</td><!--!-->
-<td><!--!-->-11.7A</td><!--!-->
-<td>2026-07-29 14:22:30.207Z</td></tr></tbody></table></div></div>
+<tbody></tbody></table></div></div>
 </body></html>

--- a/custom_components/enpal_webparser/tests/fixtures/deviceMessages851.html
+++ b/custom_components/enpal_webparser/tests/fixtures/deviceMessages851.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html><head><title>Device Messages</title></head>
+<body>
+<p>Solar Rel. 8.51.0-950631 (28.07.2026)</p>
+<div class="card mb-4"><!--!--><div class="card-header"><h2>Site Data</h2></div>
+<div class="card-body"><!--!--><!--!-->
+<table class="table table-bordered table-striped"><!--!--><thead><tr><th class="col-3">Sensor Name</th>
+<th class="col-3">Value</th>
+<th class="col-3">Timestamp</th></tr></thead>
+<tbody><tr class="dp-flash"><td>Energy.Consumption.Total.Day</td><!--!-->
+<td><!--!-->17.8kWh</td><!--!-->
+<td>2026-07-29 14:22:05.600Z</td></tr><tr class=""><td>Energy.Consumption.Total.Lifetime</td><!--!-->
+<td><!--!-->31036.1kWh</td><!--!-->
+<td>2026-07-29 14:11:21.645Z<!--!--><span class="m-3" style="color: orange" title="This data is more than 5 minutes old">⚠️</span></td></tr><tr class="dp-flash"><td>Power.Consumption.Total</td><!--!-->
+<td><!--!-->0W</td><!--!-->
+<td>2026-07-29 14:22:03.943Z</td></tr></tbody></table></div></div>
+<div class="card mb-4"><div class="card-header d-flex justify-content-between align-items-center"><div><h2>Battery</h2><!--!-->
+<span>HuaweiDongleBattery</span></div><div><div class="form-check"><input class="form-check-input" id="showUnsupported_Battery" type="checkbox"/><!--!-->
+<label class="form-check-label" for="showUnsupported_Battery"><!--!-->
+                            Show unsupported values
+                        </label></div><!--!-->
+<div class="form-check"><input class="form-check-input" id="showInternal_Battery" type="checkbox"/><!--!-->
+<label class="form-check-label" for="showInternal_Battery"><!--!-->
+                            Show internal values
+                        </label></div></div></div><!--!-->
+<div class="card-body"><!--!--><!--!-->
+<table class="table table-bordered table-striped"><!--!--><thead><tr><th class="col-3 text-center" rowspan="2">Sensor Name</th>
+<th class="col-6 text-center" colspan="2">Last Available Value</th>
+<th class="col-3 text-center" rowspan="2">Notes</th></tr>
+<tr><th class="col-3 text-center">Value</th>
+<th class="text-nowrap text-center" style="width: 1%;">Received at</th></tr></thead>
+<tbody><tr class="pi-row-error"><td>Power.AC.Max.Battery</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: The value has been cleared.</span></td></tr><tr class="pi-row-error"><td>SerialNumber.Battery.Unit.1</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: The value has been cleared.</span></td></tr><tr class="pi-row-error"><td>SerialNumber.Battery.Unit.2</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: The value has been cleared.</span></td></tr></tbody></table></div></div>
+<div class="card mb-4"><div class="card-header d-flex justify-content-between align-items-center"><div><h2>IoTEdgeDevice</h2><!--!-->
+<span>IoTEdgeDevice</span></div><div><div class="form-check"><input class="form-check-input" id="showUnsupported_IoTEdgeDevice" type="checkbox"/><!--!-->
+<label class="form-check-label" for="showUnsupported_IoTEdgeDevice"><!--!-->
+                            Show unsupported values
+                        </label></div><!--!-->
+<div class="form-check"><input class="form-check-input" id="showInternal_IoTEdgeDevice" type="checkbox"/><!--!-->
+<label class="form-check-label" for="showInternal_IoTEdgeDevice"><!--!-->
+                            Show internal values
+                        </label></div></div></div><!--!-->
+<div class="card-body"><!--!--><!--!-->
+<table class="table table-bordered table-striped"><!--!--><thead><tr><th class="col-3 text-center" rowspan="2">Sensor Name</th>
+<th class="col-6 text-center" colspan="2">Last Available Value</th>
+<th class="col-3 text-center" rowspan="2">Notes</th></tr>
+<tr><th class="col-3 text-center">Value</th>
+<th class="text-nowrap text-center" style="width: 1%;">Received at</th></tr></thead>
+<tbody><tr class="dp-flash pi-row-validation"><td>Cpu.Load</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">invalid: Cpu.Load unit type is incorrect. Expected: None, Value: Percent</span></td></tr><tr class=""><td>Device.Name</td><td>test-device</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:08:28.29</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Generation.HW</td><td>1.0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:09:10.41</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Generation.SW</td><td>2.0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:08:28.28</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>HW.Cronny.Result</td><td>cronny.hw_metrics.ok</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:15.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>IoT.Data.Consumption.Lan.Down.Month</td><td><!--!-->26196</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:15.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>IoT.Data.Consumption.Lan.Up.Month</td><td><!--!-->7735</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:15.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>IoT.Data.Consumption.Lte.Down.Month</td><td><!--!-->0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:08:55.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>IoT.Data.Consumption.Lte.Up.Month</td><td><!--!-->0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:08:55.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>IoT.MainState</td><td>Operation</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:30.30</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>IoTEdgeDevice.Device.Type</td><td>imx8mmebcrs08a2</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:08:28.28</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>IoTEdgeDevice.SerialNumber</td><td>0000000000000000000000000000dead</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:08:28.11</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.MmRestart.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.MmRestart.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemAirplaneModeSwitch.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemAirplaneModeSwitch.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemFrequencyClear.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemFrequencyClear.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemHardReset.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemHardReset.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemManagerErr.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemManagerErr.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemManagerErr.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemManagerErr.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.CountSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.CountSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.ModemSoftReset.LastTimeSuccess</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.ModemSoftReset.LastTimeSuccess } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkError.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkError.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkError.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkError.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorLowSignal.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorLowSignal.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorLowSignal.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorLowSignal.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorNoIp.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorNoIp.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.NetworkErrorNoIp.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.NetworkErrorNoIp.LastTime } has not been set</span></td></tr><tr class=""><td>LTE.CellularGuard.Result.Timestamp</td><td>2026-07-29T14:19:00Z</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:19:00.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>LTE.CellularGuard.Result.Value</td><td>cg.modem_lsusb_no_info</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:19:00.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>LTE.CellularGuard.Result.Version</td><td>v6.3</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:19:00.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.SimError.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.SimError.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.SimError.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.SimError.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.SimError10.Count</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.SimError10.Count } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.CellularGuard.SimError10.LastTime</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = LTE.CellularGuard.SimError10.LastTime } has not been set</span></td></tr><tr class="pi-row-error"><td>LTE.Connection.Type</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: ConnectionType is not available</span></td></tr><tr class="dp-flash"><td>LTE.Cronny.Result</td><td>cronny.lte_signal.no_lte</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:15.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>LTE.Failover.Result</td><td>cronny.lte_failover.lan_only</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:20:09.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>LTE.Modem.Firmware.Version</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: ModemFirmwareVersion is not available</span></td></tr><tr class="pi-row-error"><td>LTE.Modem.Type</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: ModemType is not available</span></td></tr><tr class=""><td>LTE.Predictor.Id</td><td>GaussianNB_bandwidth_acceptable_20231014_091157</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:08:28.30</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>LTE.Predictor.Result.Passed</td><td><!--!-->0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:30.30</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>LTE.Quality</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Quality is not available</span></td></tr><tr class="pi-row-error"><td>LTE.RSRP</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: RSRP is not available</span></td></tr><tr class="pi-row-error"><td>LTE.RSRQ</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: RSRQ is not available</span></td></tr><tr class="pi-row-error"><td>LTE.RSSI</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: RSSI is not available</span></td></tr><tr class="pi-row-error"><td>LTE.SNR</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: SNR is not available</span></td></tr><tr class="pi-row-error"><td>LTE.State</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: State is not available</span></td></tr><tr class="dp-flash pi-row-validation"><td>Memory.Usage</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">invalid: Memory.Usage unit type is incorrect. Expected: None, Value: Percent</span></td></tr></tbody></table></div></div>
+<div class="card mb-4"><div class="card-header d-flex justify-content-between align-items-center"><div><h2>PowerSensor</h2><!--!-->
+<span>HuaweiPowerMeter</span></div><div><div class="form-check"><input class="form-check-input" id="showUnsupported_PowerSensor" type="checkbox"/><!--!-->
+<label class="form-check-label" for="showUnsupported_PowerSensor"><!--!-->
+                            Show unsupported values
+                        </label></div><!--!-->
+<div class="form-check"><input class="form-check-input" id="showInternal_PowerSensor" type="checkbox"/><!--!-->
+<label class="form-check-label" for="showInternal_PowerSensor"><!--!-->
+                            Show internal values
+                        </label></div></div></div><!--!-->
+<div class="card-body"><!--!--><!--!-->
+<table class="table table-bordered table-striped"><!--!--><thead><tr><th class="col-3 text-center" rowspan="2">Sensor Name</th>
+<th class="col-6 text-center" colspan="2">Last Available Value</th>
+<th class="col-3 text-center" rowspan="2">Notes</th></tr>
+<tr><th class="col-3 text-center">Value</th>
+<th class="text-nowrap text-center" style="width: 1%;">Received at</th></tr></thead>
+<tbody><tr class="pi-row-error"><td>Meter.Connect.State</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter.Connect.State } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter.Enable.Disable</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter.Enable.Disable } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Phase.A</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Phase.A } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Phase.B</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Phase.B } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Phase.C</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Phase.C } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.AC.Total</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.AC.Total } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.Connect.State</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.Connect.State } has not been set</span></td></tr><tr class="pi-row-error"><td>Meter2.Enable.Disable</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Meter2.Enable.Disable } has not been set</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.A</td><td><!--!-->-3094W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.B</td><td><!--!-->-2691W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.C</td><td><!--!-->-2414W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>Power.Factor</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Power.Factor } has not been set</span></td></tr><tr class="pi-row-error"><td>Power.Reactive</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Power.Reactive } has not been set</span></td></tr><tr class="dp-flash"><td>Voltage.Phase.A</td><td><!--!-->236.6V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:21:41.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Voltage.Phase.B</td><td><!--!-->234.5V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:21:41.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Voltage.Phase.C</td><td><!--!-->234.8V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:21:41.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr></tbody></table></div></div>
+<div class="card mb-4"><div class="card-header d-flex justify-content-between align-items-center"><div><h2>Wallbox</h2><!--!-->
+<span>StarchargeWallbox</span></div><div><div class="form-check"><input class="form-check-input" id="showUnsupported_Wallbox" type="checkbox"/><!--!-->
+<label class="form-check-label" for="showUnsupported_Wallbox"><!--!-->
+                            Show unsupported values
+                        </label></div><!--!-->
+<div class="form-check"><input class="form-check-input" id="showInternal_Wallbox" type="checkbox"/><!--!-->
+<label class="form-check-label" for="showInternal_Wallbox"><!--!-->
+                            Show internal values
+                        </label></div></div></div><!--!-->
+<div class="card-body"><!--!--><!--!-->
+<table class="table table-bordered table-striped"><!--!--><thead><tr><th class="col-3 text-center" rowspan="2">Sensor Name</th>
+<th class="col-6 text-center" colspan="2">Last Available Value</th>
+<th class="col-3 text-center" rowspan="2">Notes</th></tr>
+<tr><th class="col-3 text-center">Value</th>
+<th class="text-nowrap text-center" style="width: 1%;">Received at</th></tr></thead>
+<tbody><tr class="pi-row-error"><td>ChargeBox.SerialNumber</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = ChargeBox.SerialNumber } has not been set</span></td></tr><tr class=""><td>ChargePoint.SerialNumber</td><td>1000000001</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:10:10.67</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>ChargePoint.SerialNumber.Property</td><td>1000000001</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:10:10.67</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Count.Wallbox.Connector.1.Phases.Charging</td><td><!--!-->3</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:35.50</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Current.Wallbox.Connector.1.Phase.A</td><td><!--!-->0.01A</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Current.Wallbox.Connector.1.Phase.B</td><td><!--!-->0A</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Current.Wallbox.Connector.1.Phase.C</td><td><!--!-->0A</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Energy.Wallbox.Connector.1.Charged.Total</td><td><!--!-->12642330Wh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Mode.Charge.Connector.1</td><td>Fast</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:09:09.50</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.Wallbox.Connector.1.Charging</td><td><!--!-->2W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Power.Wallbox.Connector.1.Charging.Requested</td><td><!--!-->11000W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:20.50</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.Wallbox.Connector.1.Offered</td><td><!--!-->11209W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>State.Wallbox.Connector.1.Charge</td><td><!--!-->0%</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Status.Wallbox.Connected</td><td><!--!-->1</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:35.50</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Status.Wallbox.Connector.1</td><td>Preparing</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:10:24.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Version.SW.Wallbox</td><td>2.0.1.3.3b118</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:10:10.67</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Voltage.Wallbox.Connector.1.Phase.A</td><td><!--!-->236.5V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Voltage.Wallbox.Connector.1.Phase.B</td><td><!--!-->235.4V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Voltage.Wallbox.Connector.1.Phase.C</td><td><!--!-->235.2V</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:14.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class=""><td>Wallbox.DeviceId</td><td>1000000001</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:10:10.67</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Wallbox.Settings.AutomaticChargeStatus.Connector.1</td><td>Off</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:20.50</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>Wallbox.Settings.GunLockStatus.Connector.1</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Wallbox.Settings.GunLockStatus.Connector.1 } has not been set</span></td></tr><tr class=""><td>Wallbox.Settings.MinimumChargeCurrent.Connector.1</td><td><!--!-->6A</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:08:37.37</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr></tbody></table></div></div>
+<div class="card mb-4"><div class="card-header d-flex justify-content-between align-items-center"><div><h2>Inverter</h2><!--!-->
+<span>HuaweiDongleInverter</span></div><div><div class="form-check"><input class="form-check-input" id="showUnsupported_Inverter" type="checkbox"/><!--!-->
+<label class="form-check-label" for="showUnsupported_Inverter"><!--!-->
+                            Show unsupported values
+                        </label></div><!--!-->
+<div class="form-check"><input class="form-check-input" id="showInternal_Inverter" type="checkbox"/><!--!-->
+<label class="form-check-label" for="showInternal_Inverter"><!--!-->
+                            Show internal values
+                        </label></div></div></div><!--!-->
+<div class="card-body"><!--!--><!--!-->
+<table class="table table-bordered table-striped"><!--!--><thead><tr><th class="col-3 text-center" rowspan="2">Sensor Name</th>
+<th class="col-6 text-center" colspan="2">Last Available Value</th>
+<th class="col-3 text-center" rowspan="2">Notes</th></tr>
+<tr><th class="col-3 text-center">Value</th>
+<th class="text-nowrap text-center" style="width: 1%;">Received at</th></tr></thead>
+<tbody><tr class="dp-flash"><td>Energy.Battery.Charge.Day.Inverter</td><td><!--!-->10.69kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:05.59</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Energy.Battery.Discharge.Day.Inverter</td><td><!--!-->7.76kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:05.60</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Energy.Grid.Export.Day</td><td><!--!-->1.38kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash pi-row-validation"><td>Energy.Grid.Export.Lifetime</td><td><!--!-->9354.59kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:11:21.64</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">more recent value invalid: Time Current between values is too large. 674 Seconds.</span></td></tr><tr class="dp-flash"><td>Energy.Grid.Import.Day</td><td><!--!-->0kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Energy.Grid.Import.Lifetime</td><td><!--!-->14089.4kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:21:41.01</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Energy.Production.Total.Day</td><td><!--!-->22.11kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:04.45</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Energy.Production.Total.Lifetime</td><td><!--!-->26608.26kWh</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:15:48.32</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>Inverter.Power.Total</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Inverter.Power.Total } has not been set</span></td></tr><tr class="pi-row-error"><td>Inverter.System.State</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Inverter.System.State } has not been set</span></td></tr><tr class="pi-row-error"><td>Mode.Forcible.Charge.Discharge.Inverter</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Mode.Forcible.Charge.Discharge.Inverter } has not been set</span></td></tr><tr class="pi-row-error"><td>Mode.Power.Active</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Mode.Power.Active } has not been set</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.A.Inverter</td><td><!--!-->-3094W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.B.Inverter</td><td><!--!-->-2691W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.AC.Phase.C.Inverter</td><td><!--!-->-2414W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class=""><td>Power.Battery.Charge.Discharge.Inverter</td><td><!--!-->0W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:21:26.07</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>Power.Battery.Charge.Max.Inverter</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Power.Battery.Charge.Max.Inverter } has not been set</span></td></tr><tr class="pi-row-error"><td>Power.Battery.Discharge.Max.Inverter</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Power.Battery.Discharge.Max.Inverter } has not been set</span></td></tr><tr class="dp-flash"><td>Power.DC.Total</td><td><!--!-->4966W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:21:37.74</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Power.DC.Total.Huawei</td><td><!--!-->4966W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:21:37.74</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>Power.Grid.Export</td><td><!--!-->8199W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:22:03.94</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">calculated value</span></td></tr><tr class="dp-flash"><td>Power.Grid.Export.Huawei</td><td><!--!-->8171W</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:21:41.00</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="pi-row-error"><td>Power.Grid.Maximum.Feed</td><td class="pi-note-cell" colspan="3"><span class="pi-note-text" tabindex="0">missing: Device provided value ProcessImageValueKey { KeyString = Power.Grid.Maximum.Feed } has not been set</span></td></tr><tr class="dp-flash"><td>State.AlarmCodes.1</td><td><!--!-->0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:21:28.40</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>State.AlarmCodes.2</td><td><!--!-->0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:21:28.40</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr><tr class="dp-flash"><td>State.AlarmCodes.3</td><td><!--!-->0</td><!--!-->
+<td class="text-nowrap" style="width: 1%;">14:21:28.40</td><!--!-->
+<td class="pi-note-cell"><span class="pi-note-text" tabindex="0">direct from device</span></td></tr></tbody></table></div></div>
+<div class="card mb-4"><!--!--><div class="card-header"><h2>Averaged/interpolated VPP Values</h2></div>
+<div class="card-body"><!--!--><!--!-->
+<table class="table table-bordered table-striped"><!--!--><thead><tr><th class="col-3">Sensor Name</th>
+<th class="col-3">Value</th>
+<th class="col-3">Timestamp</th></tr></thead>
+<tbody></tbody></table><!--!-->
+<!--!--><h3>Power values</h3>
+<!--!--><!--!--><!--!--><!--!-->
+<!--!--><!--!--><!--!-->
+<!--!-->
+<!--!-->
+<!--!--><!--!--><!--!-->
+<!--!--><!--!-->
+<!--!-->
+<!--!-->
+<div _bl_2a19aba8-0015-4329-bf98-e38c90675959="" class="rz-chart rz-scheme-pastel" id="3MjwVKpMoE"><!--!-->
+<!--!--><!--!-->
+<!--!--> <div class="rz-legend rz-legend-right"><!--!-->
+<ul class="rz-legend-items"><!--!-->
+</ul><!--!-->
+</div><!--!-->
+<!--!-->
+<svg style="width: 100%; height: 100%"><!--!-->
+<g transform="translate(0, 32)"><!--!-->
+<!--!--><defs><!--!-->
+<clippath id="clipPath3MjwVKpMoE"><!--!-->
+<path d="M 0 236 L 1056.4000244140625 236 L 1056.4000244140625 0 L 0 0"></path><!--!-->
+</clippath><!--!-->
+</defs><!--!-->
+</g><!--!-->
+</svg><!--!-->
+<!--!--><!--!-->
+<!--!-->
+<!--!-->
+</div><!--!-->
+<!--!-->
+<!--!--><h3>Energy counters</h3>
+<!--!--><!--!--><!--!--><!--!-->
+<!--!--><!--!--><!--!-->
+<!--!-->
+<!--!-->
+<!--!--><!--!--><!--!-->
+<!--!--><!--!-->
+<!--!-->
+<!--!-->
+<div _bl_a81b4613-b094-4ea9-bf8d-c1d018012997="" class="rz-chart rz-scheme-pastel" id="rnm-nnJzuU"><!--!-->
+<!--!--><!--!-->
+<!--!--> <div class="rz-legend rz-legend-right"><!--!-->
+<ul class="rz-legend-items"><!--!-->
+</ul><!--!-->
+</div><!--!-->
+<!--!-->
+<svg style="width: 100%; height: 100%"><!--!-->
+<g transform="translate(0, 32)"><!--!-->
+<!--!--><defs><!--!-->
+<clippath id="clipPathrnm-nnJzuU"><!--!-->
+<path d="M 0 236 L 1056.4000244140625 236 L 1056.4000244140625 0 L 0 0"></path><!--!-->
+</clippath><!--!-->
+</defs><!--!-->
+</g><!--!-->
+</svg><!--!-->
+<!--!--><!--!-->
+<!--!-->
+<!--!-->
+</div><!--!-->
+<!--!-->
+<!--!--><h3>Energy counters interpolation differences</h3>
+<!--!--><!--!--><!--!--><!--!-->
+<!--!--><!--!--><!--!-->
+<!--!-->
+<!--!-->
+<!--!--><!--!--><!--!-->
+<!--!--><!--!-->
+<!--!-->
+<!--!-->
+<div _bl_f6d638e3-e77e-4f6d-9e36-c30f30773ea8="" class="rz-chart rz-scheme-pastel" id="lpx9yzGrkE"><!--!-->
+<!--!--><!--!-->
+<!--!--> <div class="rz-legend rz-legend-right"><!--!-->
+<ul class="rz-legend-items"><!--!-->
+</ul><!--!-->
+</div><!--!-->
+<!--!-->
+<svg style="width: 100%; height: 100%"><!--!-->
+<g transform="translate(0, 32)"><!--!-->
+<!--!--><defs><!--!-->
+<clippath id="clipPathlpx9yzGrkE"><!--!-->
+<path d="M 0 236 L 1056.4000244140625 236 L 1056.4000244140625 0 L 0 0"></path><!--!-->
+</clippath><!--!-->
+</defs><!--!-->
+</g><!--!-->
+</svg><!--!-->
+<!--!--><!--!-->
+<!--!-->
+<!--!-->
+</div><!--!-->
+</div></div>
+<div class="card mb-4"><!--!--><div class="card-header"><h2>Uncategorized DataPoints</h2></div>
+<div class="card-body"><!--!--><!--!-->
+<table class="table table-bordered table-striped"><!--!--><thead><tr><th class="col-3">Sensor Name</th>
+<th class="col-3">Value</th>
+<th class="col-3">Timestamp</th></tr></thead>
+<tbody><tr class=""><td>Current.Phase.B</td><!--!-->
+<td><!--!-->-11.7A</td><!--!-->
+<td>2026-07-29 14:22:30.207Z</td></tr></tbody></table></div></div>
+</body></html>

--- a/custom_components/enpal_webparser/tests/test_utils_firmware_851.py
+++ b/custom_components/enpal_webparser/tests/test_utils_firmware_851.py
@@ -1,0 +1,65 @@
+"""Parsing of the deviceMessages page as rendered by Enpal firmware 8.51.
+
+Firmware 8.51 added a "Notes" column to every sensor table and renamed several
+inverter data points (see issue #148).
+"""
+
+from custom_components.enpal_webparser.utils import make_id, parse_enpal_html_sensors
+
+GROUPS = ["Site Data", "IoTEdgeDevice", "Inverter", "Battery", "PowerSensor", "Wallbox"]
+
+
+def _by_id(sensors):
+    return {make_id(s["name"]): s for s in sensors}
+
+
+def test_note_rows_are_not_parsed_as_values(real_html_851):
+    sensors = parse_enpal_html_sensors(real_html_851, groups=GROUPS)
+
+    assert sensors
+    for sensor in sensors:
+        value = sensor["value"]
+        assert not value.startswith("missing:")
+        assert not value.startswith("invalid:")
+        assert "ProcessImageValueKey" not in value
+
+
+def test_sensor_without_value_is_omitted(real_html_851):
+    """Cpu.Load only has a validation note, so no sensor must be produced."""
+    sensors = parse_enpal_html_sensors(real_html_851, groups=GROUPS)
+
+    assert "iotedgedevice_cpu_load" not in _by_id(sensors)
+    assert "iotedgedevice_memory_usage" not in _by_id(sensors)
+
+
+def test_values_and_units_are_still_parsed(real_html_851):
+    sensors = _by_id(parse_enpal_html_sensors(real_html_851, groups=GROUPS))
+
+    power_dc = sensors["inverter_power_dc_total"]
+    assert power_dc["value"] == "4966"
+    assert power_dc["unit"] == "W"
+    assert power_dc["device_class"] == "power"
+
+    # Wh is still normalized to kWh with the extra Notes column present.
+    charged = sensors["energy_wallbox_connector_1_charged_total"]
+    assert charged["value"] == "12642.33"
+    assert charged["unit"] == "kWh"
+
+
+def test_renamed_inverter_keys_keep_their_legacy_ids(real_html_851):
+    sensors = _by_id(parse_enpal_html_sensors(real_html_851, groups=["Inverter"]))
+
+    # Power.AC.Phase.A.Inverter must not create a second entity.
+    assert "inverter_power_ac_phase_a" in sensors
+    assert "power_ac_phase_a_inverter" not in sensors
+    assert sensors["inverter_power_ac_phase_a"]["value"] == "-3094"
+
+    assert "inverter_energy_battery_charge_day" in sensors
+    assert "inverter_power_battery_charge_discharge" in sensors
+
+
+def test_wallbox_status_source_is_still_detected(real_html_851):
+    sensors = _by_id(parse_enpal_html_sensors(real_html_851, groups=["Wallbox"]))
+
+    assert sensors["status_wallbox_connector_1"]["value"] == "Preparing"
+    assert sensors["wallbox_mode_charge_connector_1"]["value"] == "Fast"

--- a/custom_components/enpal_webparser/tests/test_utils_firmware_851.py
+++ b/custom_components/enpal_webparser/tests/test_utils_firmware_851.py
@@ -1,16 +1,27 @@
 """Parsing of the deviceMessages page as rendered by Enpal firmware 8.51.
 
 Firmware 8.51 added a "Notes" column to every sensor table and renamed several
-inverter data points (see issue #148).
+inverter data points (see issue #148). Fixture: Solar Rel. 8.51.0-955735.
 """
 
-from custom_components.enpal_webparser.utils import make_id, parse_enpal_html_sensors
+from custom_components.enpal_webparser.utils import (
+    firmware_supports_websocket,
+    make_id,
+    parse_enpal_html_sensors,
+    parse_firmware_version,
+)
 
 GROUPS = ["Site Data", "IoTEdgeDevice", "Inverter", "Battery", "PowerSensor", "Wallbox"]
 
 
 def _by_id(sensors):
     return {make_id(s["name"]): s for s in sensors}
+
+
+def test_firmware_version_is_detected(real_html_851):
+    version = parse_firmware_version(real_html_851)
+    assert version == "8.51.0"
+    assert firmware_supports_websocket(version) is True
 
 
 def test_note_rows_are_not_parsed_as_values(real_html_851):
@@ -22,27 +33,29 @@ def test_note_rows_are_not_parsed_as_values(real_html_851):
         assert not value.startswith("missing:")
         assert not value.startswith("invalid:")
         assert "ProcessImageValueKey" not in value
+        assert len(value) <= 255
 
 
 def test_sensor_without_value_is_omitted(real_html_851):
     """Cpu.Load only has a validation note, so no sensor must be produced."""
-    sensors = parse_enpal_html_sensors(real_html_851, groups=GROUPS)
+    sensors = _by_id(parse_enpal_html_sensors(real_html_851, groups=GROUPS))
 
-    assert "iotedgedevice_cpu_load" not in _by_id(sensors)
-    assert "iotedgedevice_memory_usage" not in _by_id(sensors)
+    assert "iotedgedevice_cpu_load" not in sensors
+    assert "iotedgedevice_memory_usage" not in sensors
+    assert "powersensor_power_factor" not in sensors
 
 
 def test_values_and_units_are_still_parsed(real_html_851):
     sensors = _by_id(parse_enpal_html_sensors(real_html_851, groups=GROUPS))
 
-    power_dc = sensors["inverter_power_dc_total"]
-    assert power_dc["value"] == "4966"
+    power_dc = sensors["inverter_power_dc_total_huawei"]
+    assert power_dc["value"] == "768"
     assert power_dc["unit"] == "W"
     assert power_dc["device_class"] == "power"
 
     # Wh is still normalized to kWh with the extra Notes column present.
     charged = sensors["energy_wallbox_connector_1_charged_total"]
-    assert charged["value"] == "12642.33"
+    assert charged["value"] == "12665.76"
     assert charged["unit"] == "kWh"
 
 
@@ -52,10 +65,26 @@ def test_renamed_inverter_keys_keep_their_legacy_ids(real_html_851):
     # Power.AC.Phase.A.Inverter must not create a second entity.
     assert "inverter_power_ac_phase_a" in sensors
     assert "power_ac_phase_a_inverter" not in sensors
-    assert sensors["inverter_power_ac_phase_a"]["value"] == "-3094"
+    assert sensors["inverter_power_ac_phase_a"]["value"] == "-218"
 
-    assert "inverter_energy_battery_charge_day" in sensors
-    assert "inverter_power_battery_charge_discharge" in sensors
+    assert sensors["inverter_energy_battery_charge_day"]["value"] == "0.2"
+    assert sensors["inverter_energy_battery_discharge_day"]["value"] == "3.02"
+    assert sensors["inverter_power_battery_charge_discharge"]["value"] == "3"
+    assert sensors["inverter_power_battery_charge_max"]["value"] == "5000"
+    assert sensors["inverter_power_battery_discharge_max"]["value"] == "5000"
+    assert "inverter_mode_forcible_charge_discharge" in sensors
+
+
+def test_inverter_system_state_is_expanded(real_html_851):
+    """8.51 renders the state as a readable list instead of one raw bitfield."""
+    sensors = _by_id(parse_enpal_html_sensors(real_html_851, groups=["Inverter"]))
+
+    assert sensors["inverter_system_state_decimal"]["value"] == "6"
+    assert sensors["inverter_system_state_flags"]["value"] == (
+        "Grid-connected, Grid-connected normally"
+    )
+    assert sensors["inverter_system_state_grid_connected"]["value"] == "on"
+    assert sensors["inverter_system_state_standby"]["value"] == "off"
 
 
 def test_wallbox_status_source_is_still_detected(real_html_851):
@@ -63,3 +92,14 @@ def test_wallbox_status_source_is_still_detected(real_html_851):
 
     assert sensors["status_wallbox_connector_1"]["value"] == "Preparing"
     assert sensors["wallbox_mode_charge_connector_1"]["value"] == "Fast"
+
+
+def test_calculated_current_sensors_are_added(real_html_851):
+    """8.51 still omits Current.Phase.*, so they must be derived from P and U."""
+    sensors = _by_id(parse_enpal_html_sensors(real_html_851, groups=GROUPS))
+
+    for phase in ("a", "b", "c"):
+        current = sensors[f"powersensor_current_phase_{phase}"]
+        assert current["unit"] == "A"
+        assert current["device_class"] == "current"
+

--- a/custom_components/enpal_webparser/utils.py
+++ b/custom_components/enpal_webparser/utils.py
@@ -28,6 +28,7 @@ from .const import (
     DEFAULT_UNITS,
     DEVICE_CLASS_OVERRIDES,
     ENPAL_TIMESTAMP_FORMAT,
+    SENSOR_KEY_ALIASES,
     UNIT_DEVICE_CLASS_MAP,
 )
 
@@ -294,6 +295,18 @@ def extract_group_from_card(card: Tag) -> Optional[str]:
     return h2_tag.text.strip() if h2_tag else None
 
 
+def is_note_cell(cell: Tag) -> bool:
+    """Whether a table cell is a "Notes" placeholder instead of a sensor value.
+
+    Since firmware 8.51 the deviceMessages tables carry an extra "Notes" column.
+    Rows whose reading is missing or invalid do not render a value/timestamp at
+    all; instead a single note cell spans the remaining columns and contains
+    diagnostic text such as "missing: The value has been cleared.".
+    """
+    classes = cell.get("class") or []
+    return "pi-note-cell" in classes and cell.has_attr("colspan")
+
+
 def parse_card_rows(card: Tag, group: str, groups: List[str]) -> List[Dict[str, Any]]:
     """Extracts sensors from a group."""
     rows = card.find_all("tr")[1:]  # assume first row == header
@@ -307,7 +320,12 @@ def parse_card_rows(card: Tag, group: str, groups: List[str]) -> List[Dict[str, 
         if len(cols) < 2:
             continue
 
-        raw_name = cols[0].text.strip()
+        # No reading available for this sensor in this update - leave the
+        # entity on its last known value instead of pushing the note text.
+        if is_note_cell(cols[1]):
+            continue
+
+        raw_name = SENSOR_KEY_ALIASES.get(cols[0].text.strip(), cols[0].text.strip())
         value_raw = cols[1].text.strip()
         timestamp_str = cols[2].text.strip() if len(cols) > 2 else None
 


### PR DESCRIPTION
## Description

Enpal hat mit Firmware **Solar Rel. 8.51** die Seite `/deviceMessages` umgebaut. Zwei Änderungen brechen die bisherige Auswertung:

**1. Neue Spalte "Notes" und Notiz-Zeilen**

Jede Tabelle hat jetzt einen zweizeiligen Kopf und eine vierte Spalte "Notes". Zeilen ohne gültigen Messwert rendern keine Wert- und Zeitstempelzelle mehr, sondern eine Notiz über die restliche Breite:

```html
<tr class="pi-row-error">
  <td>Cpu.Load</td>
  <td colspan="3" class="pi-note-cell">
    <span class="pi-note-text">missing: The value has been cleared.</span>
  </td>
</tr>
```

Der Parser hat `cols[1]` als Wert gelesen und diesen Text als Sensorzustand gesetzt.

Neu ist `is_note_cell()` in `utils.py`. `parse_card_rows()` überspringt solche Zeilen. Der Sensor fällt damit in `EnpalSensor._handle_coordinator_update()` auf den letzten bekannten Wert zurück, statt Fehlertext anzuzeigen.

**2. Umbenannte Datenpunkte in der Gruppe "Inverter"**

Neun Schlüssel haben das Suffix `.Inverter` bekommen. Ohne Zuordnung entstehen neue Entity-IDs und der Verlauf reißt ab.

`SENSOR_KEY_ALIASES` in `const.py` bildet die neuen Schlüssel auf die alten ab. Angewendet wird die Tabelle in `parse_card_rows()` (HTML-Pfad) und in `websocket_client._apply_diff()` (RenderBatch-Pfad), damit beide Datenquellen dieselben IDs erzeugen.

Betroffen sind `Power.AC.Phase.A/B/C`, `Power.Battery.Charge.Discharge`, `Power.Battery.Charge.Max`, `Power.Battery.Discharge.Max`, `Energy.Battery.Charge.Day`, `Energy.Battery.Discharge.Day` und `Mode.Forcible.Charge.Discharge`.

Zusätzlich: Version auf `3.0.3b1` gesetzt und Beta-Release-Notes ergänzt.

## Motivation and Context

Fixes #148.

Enpal spielt das Update schrittweise aus. Auf betroffenen Boxen standen bei einem Nutzer 65 von 135 Sensoren auf Texten wie `missing: Device provided value ProcessImageValueKey { KeyString = Power.Reactive } has not been set`. Energie-Dashboard und Automatisierungen laufen damit ins Leere.

Die Alias-Tabelle verhindert, dass Nutzer beim Firmware-Update stillschweigend doppelte Entitäten und abgeschnittene Verläufe bekommen.

## How Has This Been Tested?

Zwei echte Seitenstände von einem betroffenen Nutzer aus Issue #148:

- `8.51.0-950631` (erster Stand, überwiegend Fehlertexte)
- `8.51.0-955735` (zweiter Stand, wieder mit Werten)

Der zweite Stand liegt gekürzt und anonymisiert als `tests/fixtures/deviceMessages851.html` im Repo. Er ist der aussagekräftigere Fall: 55 Notiz-Zeilen und gleichzeitig echte Werte inklusive `Inverter.System.State`.

Neue Testdatei `tests/test_utils_firmware_851.py` mit acht Tests:

- kein Sensorwert beginnt mit `missing:` oder `invalid:`, keiner enthält `ProcessImageValueKey`, keiner ist länger als 255 Zeichen
- Sensoren, die nur eine Notiz haben (`Cpu.Load`, `Memory.Usage`, `Power.Factor`), erzeugen keine Entität
- Werte, Einheiten und `device_class` werden weiterhin korrekt erkannt, inklusive Wh→kWh
- die neun umbenannten Schlüssel landen auf ihren bisherigen IDs, die `.Inverter`-Variante entsteht nicht
- `Inverter.System.State` wird korrekt in Einzelsensoren aufgeteilt
- die Wallbox-Statusquelle wird weiterhin gefunden
- die berechneten `Current.Phase.*` entstehen weiterhin aus P und U
- Firmware-Erkennung liefert `8.51.0` und gibt den WebSocket-Modus frei

Ergebnis auf der neuen Fixture: **92 Sensoren, 0 Fehlertext-Werte, 0 Werte über 255 Zeichen**.

Vollständiger Lauf:

```powershell
$env:PYTHONPATH = "e:\Github\enpal"
pytest -q
# 102 passed
```

Die bestehenden Tests gegen die Firmware-8.50-Fixture laufen unverändert durch, es gibt also keine Regression für ältere Stände.

Ein RenderBatch-Mitschnitt von 8.51 lag nicht vor. Der schnelle WebSocket-Pfad überspringt unbekannte Zeilenklassen wie bisher still, der 60-Sekunden-Vollabgleich korrigiert das.

## Screenshots (if appropriate):

Siehe Screenshots im Issue #148 (Sensoren mit Fehlertext als Zustand).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.