### PR TITLE
Bugfix-Release 3.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ Eine Home Assistant Custom Integration zur lokalen Überwachung von Enpal Solara
 
 ---
 
-## 🆕 Neu in Version 3.1.1
+## 🆕 Neu in Version 3.1.2
+
+Bugfixes für Firmware **Solar Rel. 8.51.1**: Der Wallbox-Status wird wieder erkannt (die Box liefert ihn jetzt als "Connector Charging" statt "Status Charging"), die Warnungs-Flut "No suitable DC power sensor found" auf FoxESS-Systemen ist behoben und `sensor.inverter_system_state` liefert wieder einen Wert.
+
+Details in den [Release Notes 3.1.2](docs/RELEASE_NOTES_3.1.2.md).
+
+### Aus Version 3.1.1
 
 Steht die Integration fest auf dem HTML-Modus und die Enpal Box wird auf Firmware **8.51** aktualisiert, liefert die Box über HTTP keine Gerätedaten mehr. Bisher standen dann fast alle Entitäten auf "nicht verfügbar", ohne Hinweis auf die Ursache. Die Integration erkennt diese Situation jetzt und zeigt eine Reparatur-Meldung in Home Assistant. Ein Klick stellt den Datenquellen-Modus auf WebSocket um.
 

--- a/custom_components/enpal_webparser/api/wallbox_client.py
+++ b/custom_components/enpal_webparser/api/wallbox_client.py
@@ -293,10 +293,13 @@ class WallboxBlazorClient:
         if status:
             self._status = status
 
-        # Fallback: if we never got any status yet, ensure WebSocket is up
-        # so the initial RenderBatch seeds the values.
-        if self._mode is None and self._status is None:
-            if not await self.ensure_fresh_connection():
+        # Since firmware 8.51.1 the /wallbox page is no longer pre-rendered,
+        # so the HTTP poll comes back empty. The values then only refresh via
+        # WebSocket RenderBatches, so keep that connection alive (reconnects
+        # when stale). Also covers the initial seeding before the first batch.
+        if mode is None or status is None:
+            connected = await self.ensure_fresh_connection()
+            if not connected and self._mode is None and self._status is None:
                 return None
 
         return {
@@ -565,47 +568,34 @@ class WallboxBlazorClient:
 
     @staticmethod
     def _extract_status_text(data: bytes) -> tuple:
-        """Extract 'Mode X' and 'Status Y' from RenderBatch binary data."""
+        """Extract mode and status from RenderBatch binary (or HTML) data.
+
+        The mode is rendered as 'Mode <X>'. The status label depends on the
+        firmware: 'Status <Y>' up to 8.51.0, 'Connector <Y>' since 8.51.1.
+        In RenderBatch payloads the value can sit in a separate string-table
+        entry, so non-alpha bytes between label and value are skipped.
+        """
         text = data.decode('utf-8', errors='replace')
-        mode = None
-        status = None
 
-        valid_modes = {'Eco', 'Solar', 'Full', 'Smart', 'Fast'}
+        def word_after(label: str, min_len: int = 1, valid: Optional[set] = None) -> Optional[str]:
+            idx = 0
+            while True:
+                idx = text.find(label, idx)
+                if idx < 0:
+                    return None
+                after = text[idx + len(label):idx + len(label) + 25]
+                word = ''
+                for c in after:
+                    if c.isalpha():
+                        word += c
+                    elif word:
+                        break
+                if len(word) >= min_len and (valid is None or word in valid):
+                    return word
+                idx += len(label)
 
-        idx = 0
-        while True:
-            idx = text.find('Mode ', idx)
-            if idx < 0:
-                break
-            after = text[idx + 5:idx + 25]
-            word = ''
-            for c in after:
-                if c.isalpha():
-                    word += c
-                elif word:
-                    break
-            if word in valid_modes:
-                mode = word
-                break
-            idx += 5
-
-        idx = 0
-        while True:
-            idx = text.find('Status ', idx)
-            if idx < 0:
-                break
-            after = text[idx + 7:idx + 30]
-            word = ''
-            for c in after:
-                if c.isalpha():
-                    word += c
-                elif word:
-                    break
-            if word and len(word) > 2:
-                status = word
-                break
-            idx += 7
-
+        mode = word_after('Mode ', valid={'Eco', 'Solar', 'Full', 'Smart', 'Fast'})
+        status = word_after('Status ', min_len=3) or word_after('Connector ', min_len=3)
         return mode, status
 
     # ------------------------------------------------------------------

--- a/custom_components/enpal_webparser/api/websocket_client.py
+++ b/custom_components/enpal_webparser/api/websocket_client.py
@@ -716,7 +716,7 @@ class EnpalWebSocketClient(EnpalApiClient):
         parser (and entity ids) keep working. Returns the number of newly
         created sensors.
         """
-        from ..utils import make_id, expand_inverter_system_state
+        from ..utils import make_id, friendly_name, expand_inverter_system_state
         from ..const import SENSOR_KEY_GROUPS
 
         group = SENSOR_KEY_GROUPS.get("Inverter.System.State")
@@ -730,7 +730,23 @@ class EnpalWebSocketClient(EnpalApiClient):
         created = 0
         enabled = group not in self.excluded_groups
         prefix = f"{group}: "
-        for sensor in expand_inverter_system_state(group, text, row.get("timestamp")):
+        # The HTML parser keeps the base "System State" sensor alongside the
+        # split sensors (truncated to a valid state length). Mirror that here,
+        # otherwise sensor.inverter_system_state stays unavailable on firmware
+        # 8.51 where the value only arrives over the WebSocket (issue #178).
+        base_sensor = {
+            "name": friendly_name(group, "Inverter.System.State"),
+            "value": re.sub(r"\s+", " ", text).strip()[:240],
+            "unit": None,
+            "device_class": None,
+            "enabled": enabled,
+            "enpal_last_update": row.get("timestamp"),
+            "group": group,
+        }
+        sensors = [base_sensor] + expand_inverter_system_state(
+            group, text, row.get("timestamp")
+        )
+        for sensor in sensors:
             # The HTML parser creates the same sensors but without a "group"
             # field, so _set_baseline indexes them under the full name instead
             # of the label. Look up (and register) both ids to stay compatible

--- a/custom_components/enpal_webparser/manifest.json
+++ b/custom_components/enpal_webparser/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/derolli1976/enpal/issues",
   "requirements": ["beautifulsoup4", "psutil", "msgpack>=1.0.7"],
-  "version": "3.1.1"
+  "version": "3.1.2"
 }

--- a/custom_components/enpal_webparser/sensor.py
+++ b/custom_components/enpal_webparser/sensor.py
@@ -278,49 +278,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         entities.append(build_sensor_entity(sensor_dict, coordinator, use_wallbox=use_wallbox))
 
 
-    # Create cumulative energy sensor with smart fallback for different inverter types
-    
-    source_sensor = None
-    available_sensor_names = [s.get("name", "") for s in coordinator.data]
-    
-    # Priority 1: Try Huawei-specific sensor first
-    if "Inverter: Power DC Total (Huawei)" in available_sensor_names:
-        source_sensor = "Inverter: Power DC Total (Huawei)"
-        _LOGGER.info("[Enpal] Using Huawei-specific DC power sensor: %s", source_sensor)
-    
-    # Priority 2: Try other manufacturer-specific sensors (SMA, Fronius, etc.)
-    # Look for pattern: "Inverter: Power DC Total (<Manufacturer>)"
-    if not source_sensor:
-        for name in available_sensor_names:
-            name_id = make_id(name)
-            # Match manufacturer-specific format but exclude Calculated
-            if (name_id.startswith("inverter_power_dc_total_") and 
-                name_id != "inverter_power_dc_total_calculated" and
-                name_id != "inverter_power_dc_total"):
-                source_sensor = name
-                _LOGGER.info("[Enpal] Found manufacturer-specific DC power sensor: %s", name)
-                break
-    
-    # Priority 3: Try generic "Inverter: Power DC Total"
-    if not source_sensor and "Inverter: Power DC Total" in available_sensor_names:
-        source_sensor = "Inverter: Power DC Total"
-        _LOGGER.info("[Enpal] Using generic DC power sensor: %s", source_sensor)
-    
-    # Priority 4: Last resort - use calculated sensor
-    if not source_sensor and "Inverter: Power DC Total Calculated" in available_sensor_names:
-        source_sensor = "Inverter: Power DC Total Calculated"
-        _LOGGER.warning("[Enpal] Using calculated DC power sensor (least accurate): %s", source_sensor)
-    
-    # Final fallback: If nothing found, use Huawei as default (will trigger warning)
-    if not source_sensor:
-        source_sensor = "Inverter: Power DC Total (Huawei)"
-        _LOGGER.warning(
-            "[Enpal] No DC power sensor found. Available power sensors: %s. Using fallback: %s",
-            ", ".join([make_id(n) for n in available_sensor_names if "power" in make_id(n).lower()]),
-            source_sensor
-        )
-    
-    entities.append(CumulativeEnergySensor(hass, coordinator, [source_sensor], interval))
+    # The DC power source is selected inside the entity and re-tried on every
+    # coordinator update: on firmware 8.51 the first fetch only carries the
+    # pre-rendered Site Data card, the inverter sensors arrive a few seconds
+    # later via WebSocket push (issue #177). Selecting the source once at
+    # setup would therefore always miss them.
+    entities.append(CumulativeEnergySensor(
+        hass, coordinator, ["Inverter: Power DC Total (Huawei)"], interval
+    ))
     entities.append(DailyResetFromEntitySensor(hass, "sensor.inverter_energy_produced_total_dc"))
 
     if entry.options.get("use_wallbox", False):
@@ -441,6 +406,7 @@ class CumulativeEnergySensor(SensorEntity, RestoreEntity):
         self._coordinator = coordinator
         self._source_candidates = [make_id(name) for name in sensor_names]
         self._active_source_uid = None  # Will be determined from available sensors
+        self._source_warning_logged = False
         self._fallback_interval_hours = interval_seconds / 3600
         self._last_update_time = None  # Track real elapsed time between updates
         self._state = self.hass.data[DOMAIN]["cumulative_energy_state"]
@@ -471,23 +437,46 @@ class CumulativeEnergySensor(SensorEntity, RestoreEntity):
             self._value = 0.0
         self._coordinator.async_add_listener(self._handle_coordinator_update)
 
+    def _select_source_uid(self, available_ids: set) -> str | None:
+        """Pick the best DC power sensor from the currently available ids.
+
+        Priority: explicit candidates (Huawei), then manufacturer-specific
+        sensors (SMA, FoxESS, ...), then the generic sensor, then the
+        calculated one as last resort.
+        """
+        for candidate in self._source_candidates:
+            if candidate in available_ids:
+                return candidate
+        for uid in sorted(available_ids):
+            if (uid.startswith("inverter_power_dc_total_")
+                    and uid != "inverter_power_dc_total_calculated"):
+                return uid
+        if "inverter_power_dc_total" in available_ids:
+            return "inverter_power_dc_total"
+        if "inverter_power_dc_total_calculated" in available_ids:
+            return "inverter_power_dc_total_calculated"
+        return None
+
     def _handle_coordinator_update(self):
         # If we haven't determined the active source yet, find the first available one
         if self._active_source_uid is None:
             available_sensors = {make_id(s["name"]) for s in self._coordinator.data}
-            for candidate in self._source_candidates:
-                if candidate in available_sensors:
-                    self._active_source_uid = candidate
-                    _LOGGER.info("[Enpal] Using DC power sensor: %s", candidate)
-                    break
-            
+            self._active_source_uid = self._select_source_uid(available_sensors)
+
             if self._active_source_uid is None:
-                _LOGGER.warning(
-                    "[Enpal] No suitable DC power sensor found. Tried: %s",
-                    ", ".join(self._source_candidates)
-                )
+                # On firmware 8.51 the inverter sensors only arrive via
+                # WebSocket push a few seconds after setup, so keep retrying
+                # on every update but log the warning only once (issue #177).
+                if not self._source_warning_logged:
+                    self._source_warning_logged = True
+                    _LOGGER.warning(
+                        "[Enpal] No suitable DC power sensor found. Tried: %s. "
+                        "Will keep looking on further updates",
+                        ", ".join(self._source_candidates)
+                    )
                 self.async_write_ha_state()
                 return
+            _LOGGER.info("[Enpal] Using DC power sensor: %s", self._active_source_uid)
         
         # Now process the update with the active source
         now = datetime.now()

--- a/custom_components/enpal_webparser/tests/test_render_batch.py
+++ b/custom_components/enpal_webparser/tests/test_render_batch.py
@@ -458,6 +458,12 @@ def test_system_state_row_expands_into_split_sensors():
     )
     assert by_id["inverter_system_state_standby"]["value"] == "off"
     assert by_id["inverter_system_state_grid_connected"]["value"] == "on"
+    # The base sensor keeps its historic entity id and a truncated, tag-free
+    # value, like the 8.50 HTML parser (issue #178).
+    base = by_id["inverter_system_state"]
+    assert base["value"].startswith("Decimal: 6")
+    assert "<" not in base["value"]
+    assert len(base["value"]) <= 240
     # No raw sensor with the oversized HTML blob as state.
     for sensor in client._baseline:
         assert len(str(sensor["value"])) <= 255
@@ -474,6 +480,7 @@ def test_system_state_row_expands_into_split_sensors():
     assert by_id["inverter_system_state_decimal"]["value"] == "1"
     assert by_id["inverter_system_state_standby"]["value"] == "on"
     assert by_id["inverter_system_state_grid_connected"]["value"] == "off"
+    assert by_id["inverter_system_state"]["value"].startswith("Decimal: 1")
 
 
 def test_system_state_row_respects_group_selection():

--- a/custom_components/enpal_webparser/tests/test_sensor_selection.py
+++ b/custom_components/enpal_webparser/tests/test_sensor_selection.py
@@ -216,6 +216,55 @@ class TestCumulativeEnergySensorSelection:
             # Should NOT match any of these wrong sensors
             assert sensor._active_source_uid is None
             mock_logger.warning.assert_called_once()
+
+    def test_source_found_on_later_update(self, mock_hass, mock_coordinator):
+        """Sensors arriving after setup are picked up on a later update.
+
+        On firmware 8.51 the first fetch only carries the Site Data card; the
+        inverter sensors arrive a few seconds later via WebSocket push
+        (issue #177). The warning must be logged only once, not per update.
+        """
+        mock_coordinator.data = [
+            {"name": "Site Data: Power Consumption Total", "value": "9000", "timestamp": "01/01/2024 12:00:00"},
+        ]
+
+        with patch('custom_components.enpal_webparser.sensor._LOGGER') as mock_logger:
+            sensor = create_sensor_with_mocked_state(
+                mock_hass, mock_coordinator, ["Inverter: Power DC Total (Huawei)"]
+            )
+            sensor._value = 0.0
+            sensor._handle_coordinator_update()
+            sensor._handle_coordinator_update()
+            sensor._handle_coordinator_update()
+
+            # No source yet, warning logged exactly once despite three updates
+            assert sensor._active_source_uid is None
+            mock_logger.warning.assert_called_once()
+
+            # FoxESS box: the generic DC sensor appears via WebSocket push
+            mock_coordinator.data = [
+                {"name": "Site Data: Power Consumption Total", "value": "9000", "timestamp": "01/01/2024 12:00:00"},
+                {"name": "Inverter: Power DC Total", "value": "5000", "timestamp": "01/01/2024 12:00:05"},
+            ]
+            sensor._handle_coordinator_update()
+
+            assert sensor._active_source_uid == "inverter_power_dc_total"
+            mock_logger.warning.assert_called_once()
+
+    def test_manufacturer_specific_beats_generic(self, mock_hass, mock_coordinator):
+        """Manufacturer-specific sensors win over generic even without being a candidate."""
+        mock_coordinator.data = [
+            {"name": "Inverter: Power DC Total", "value": "5000", "timestamp": "01/01/2024 12:00:00"},
+            {"name": "Inverter: Power DC Total (SMA)", "value": "5100", "timestamp": "01/01/2024 12:00:00"},
+        ]
+
+        sensor = create_sensor_with_mocked_state(
+            mock_hass, mock_coordinator, ["Inverter: Power DC Total (Huawei)"]
+        )
+        sensor._handle_coordinator_update()
+
+        assert sensor._active_source_uid == "inverter_power_dc_total_sma"
+
     
     def test_multiple_matching_sensors_first_wins(self, mock_hass, mock_coordinator):
         """Test that first matching sensor in priority order is selected.

--- a/custom_components/enpal_webparser/tests/test_wallbox_client.py
+++ b/custom_components/enpal_webparser/tests/test_wallbox_client.py
@@ -1,0 +1,51 @@
+#
+# Tests for Enpal Webparser - WallboxBlazorClient status text parsing
+#
+# The /wallbox page renders the current charge mode and connector status as
+# plain text. The status label changed with firmware 8.51.1: 'Status <X>'
+# became 'Connector <X>'. Both formats must be recognized, in pre-rendered
+# HTML as well as in RenderBatch payloads where label and value can sit in
+# separate string-table entries (separated by a VLQ length byte).
+#
+# To run: pytest custom_components/enpal_webparser/tests/test_wallbox_client.py
+#
+
+from custom_components.enpal_webparser.api.wallbox_client import WallboxBlazorClient
+
+extract = WallboxBlazorClient._extract_status_text
+
+
+def test_status_label_pre_851():
+    # Firmware <= 8.51.0: pre-rendered HTML says 'Mode Solar' / 'Status Charging'
+    data = b"<h5>Mode Solar</h5><p>Status Charging</p>"
+    assert extract(data) == ("Solar", "Charging")
+
+
+def test_connector_label_8511():
+    # Firmware 8.51.1: the status card says 'Connector Charging'
+    data = b"<h5>Mode Solar</h5><p>Connector Charging</p>"
+    assert extract(data) == ("Solar", "Charging")
+
+
+def test_connector_label_renderbatch_string_table():
+    # In RenderBatch payloads the value is a separate string-table entry,
+    # so a length byte sits between label and value.
+    data = b"junk\x0aMode \x05Solar\x0aConnector \x08Charging\x0amore"
+    assert extract(data) == ("Solar", "Charging")
+
+
+def test_status_label_wins_over_connector():
+    # Old firmware may contain both words; 'Status' stays authoritative.
+    data = b"Mode Eco ... Status Connected ... Connector Available"
+    assert extract(data) == ("Eco", "Connected")
+
+
+def test_no_match_returns_none():
+    assert extract(b"completely unrelated payload") == (None, None)
+
+
+def test_invalid_mode_word_is_ignored():
+    # 'Mode Unknown' is not a valid charge mode and must not be reported.
+    data = b"Mode Unknown ... Connector Charging"
+    assert extract(data) == (None, "Charging")
+

--- a/docs/RELEASE_NOTES_3.1.2.md
+++ b/docs/RELEASE_NOTES_3.1.2.md
@@ -1,0 +1,32 @@
+# 3.1.2 - Fixes für Firmware 8.51.1 (Wallbox-Status und DC-Leistungssensor)
+
+Bugfix-Release für zwei Probleme, die mit dem Firmware-Update auf **Solar Rel. 8.51.1** aufgetreten sind.
+
+---
+
+## 🐛 Behobene Fehler
+
+### Wallbox-Status "Unknown" auf Firmware 8.51.1
+
+Mit Firmware 8.51.1 blieb `sensor.wallbox_status` dauerhaft auf "Unknown", obwohl das Auto lud. Die Firmware hat zwei Dinge geändert: Die Seite `/wallbox` wird nicht mehr vorgerendert und die Statuskarte heißt jetzt "Connector Charging" statt "Status Charging". Die Integration liest beide Formate jetzt korrekt und hält die WebSocket-Verbindung zur Wallbox-Seite offen, damit Statusänderungen weiter ankommen. Der Lademodus war nicht betroffen.
+
+### Warnungs-Flut "No suitable DC power sensor found" (Issue #177)
+
+Seit Firmware 8.51 liefert der erste Datenabruf nur die Karte "Site Data". Die Inverter-Sensoren kommen wenige Sekunden später über den WebSocket. Die Auswahl des DC-Leistungssensors für `sensor.inverter_energy_produced_total_dc` lief aber nur einmal beim Start. Sie fand deshalb nichts, fiel fest auf den Huawei-Sensor zurück und schrieb danach bei jedem Update eine Warnung ins Log. Auf FoxESS-Systemen kamen so zehntausende Einträge zusammen.
+
+Die Sensor-Auswahl läuft jetzt bei jedem Update, bis ein passender Sensor gefunden ist. Nachträglich eintreffende Sensoren werden erkannt, auch herstellerspezifische wie bei SMA oder FoxESS. Die Warnung erscheint höchstens einmal.
+
+### Sensor "Inverter System State" dauerhaft "nicht verfügbar" (Issue #178)
+
+Seit Firmware 8.51 kommt der System-Status des Inverters nur noch über den WebSocket, als langer HTML-Block. Die Integration hat daraus zwar die aufgeteilten Sensoren erzeugt (Decimal, Flags, einzelne Bits), den Basis-Sensor `sensor.inverter_system_state` aber nicht mehr beliefert. Er stand deshalb dauerhaft auf "nicht verfügbar".
+
+Der Basis-Sensor erhält jetzt wieder einen Wert: den Statustext ohne HTML-Formatierung, gekürzt auf eine für Home Assistant gültige Länge. Das entspricht dem Verhalten aus dem HTML-Modus vor Firmware 8.51. Die Entity-ID bleibt unverändert.
+
+## 🔄 Kompatibilität
+
+- Keine Änderungen an Entity-IDs, Sensoren oder Optionen
+- Die Prioritätsreihenfolge der DC-Sensor-Auswahl bleibt unverändert: Huawei, herstellerspezifisch, generisch, berechnet
+
+## ❤️ Unterstützung
+
+Wenn dir die Integration hilft und du die Weiterentwicklung unterstützen möchtest, freue ich mich über eine Spende über die **Sponsoring-Sektion** dieses Repositories (Button "Sponsor" oben auf der [Projektseite](https://github.com/derolli1976/enpal)) oder über [Buy Me a Coffee](https://buymeacoffee.com/derolli1976). Danke!


### PR DESCRIPTION
## Description

Bugfix-Release 3.1.2 mit drei Fixes für Firmware **Solar Rel. 8.51.1**:

1. **Wallbox-Status "Unknown" (8.51.1)**: Die Firmware rendert die Seite `/wallbox` nicht mehr vor und benennt die Statuskarte von "Status Charging" in "Connector Charging" um. `WallboxBlazorClient._extract_status_text` erkennt jetzt beide Label (`Status` hat Vorrang, dann `Connector`) und überspringt die VLQ-Längenbytes zwischen String-Table-Einträgen im RenderBatch. `get_wallbox_data` hält die WebSocket-Verbindung frisch, wenn der HTTP-Poll leer bleibt, damit Statusänderungen weiter per RenderBatch ankommen.
2. **Warnungs-Flut "No suitable DC power sensor found" (#177)**: Die DC-Sensor-Auswahl lief einmalig beim Setup. Auf Firmware 8.51 enthält der erste Fetch aber nur die Site-Data-Karte, die Inverter-Sensoren kommen Sekunden später per WebSocket-Push. Die Auswahl fiel deshalb fest auf den Huawei-Sensor zurück und `CumulativeEnergySensor` warnte bei jedem Update (27716 Einträge beim Melder). Die Auswahl liegt jetzt in der Entity (`_select_source_uid`), läuft bei jedem Update bis ein Sensor gefunden ist und warnt höchstens einmal. Prioritätsreihenfolge unverändert: Huawei → herstellerspezifisch → generisch → berechnet.
3. **`sensor.inverter_system_state` dauerhaft "nicht verfügbar" (#178)**: Seit 8.51 kommt der System-Status nur noch als HTML-Blob über den WebSocket. `_apply_system_state_row` erzeugte daraus nur die Split-Sensoren, der Basis-Sensor wurde nie mehr beliefert. Er erhält jetzt wieder einen Wert (tag-frei, auf 240 Zeichen gekürzt), wie im HTML-Modus vor 8.51. Entity-ID unverändert.

Außerdem: Manifest auf 3.1.2, Release Notes [docs/RELEASE_NOTES_3.1.2.md](docs/RELEASE_NOTES_3.1.2.md), README-Abschnitt "Neu in 3.1.2".

## Motivation and Context

Das Firmware-Update auf Solar Rel. 8.51.1 hat den Wallbox-Status-Parser gebrochen und zwei bereits gemeldete Probleme sichtbar gemacht.

- Fixes #177
- Fixes #178

## How Has This Been Tested?

- **Live gegen eine echte Enpal Box mit Firmware 8.51.1-989469** (Huawei-Inverter + Starcharge-Wallbox, Auto lud während des Tests):
  - Wallbox-Client: `Mode=Solar, Status=Charging`, alle 6 Buttons erkannt (inkl. neuem `smart`)
  - WebSocket-Client: 152 Sensoren in der Baseline, `inverter_system_state = 'Decimal: 6 Bits: 0000000110 …'`, alle 12 Split-Sensoren korrekt, kein Wert über 255 Zeichen
- **Rohdaten-Analyse**: WebSocket-Sniff der Box aufgezeichnet und die RenderBatches offline mit den Parser-Funktionen der Integration verifiziert (`Status.Wallbox.Connector.1` liefert weiterhin `Charging`, das Problem lag ausschließlich im `/wallbox`-Fallback)
- **Unit-Tests**: 8 neue Tests (`test_wallbox_client.py` mit 6 Tests für beide Status-Label-Formate, 2 Tests in `test_sensor_selection.py` für verspätet eintreffende Sensoren und Warn-Deduplizierung), Assertion für den Basis-Sensor in `test_render_batch.py` ergänzt
- Komplette Suite: **139/139 Tests grün** (`pytest`, Python 3.13, Windows)

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.